### PR TITLE
Force the gem to use httpclient

### DIFF
--- a/connect_vbms.gemspec
+++ b/connect_vbms.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "equivalent-xml", "~> 0.6"
   spec.add_development_dependency "simplecov", "~> 0.10"
 
+  spec.add_runtime_dependency "httpclient", "~> 2.6"
   spec.add_runtime_dependency "httpi", "~> 2.4"
   spec.add_runtime_dependency "nokogiri", "~> 1.6"
   spec.add_runtime_dependency "xmlenc", "~> 0.2"

--- a/src/vbms.rb
+++ b/src/vbms.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require 'base64'
 require 'erb'
+require 'httpclient'
 require 'httpi'
 require 'tempfile'
 require 'uri'


### PR DESCRIPTION
Normally the HTTPI gem allows users of your gem to pick which HTTP gem they prefer and it is a simple abstraction layer above whatever adapter they prefer. We want to ensure that HTTPS connections are reused for several requests, and the best way to do that is to explicitly require the httpclient gem. This might mean more dependencies for projects that use this gem but it should also result in greater performance.

The challenge with this pull request is that I'm not sure exactly how to test this is reusing a HTTP connection. It seems like it would require someone with access to the VBMS test repository to run the integration tests while also looking at a packet sniffer or something like Little Snitch. It if opens up several HTTPS connections, it fails. If it only opens up one, it succeeds.