### PR TITLE
Print a warning when connecting to live VBMS test server

### DIFF
--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -13,7 +13,7 @@ describe VBMS::Requests do
     end
   end
 
-  describe "UploadDocumentWithAssociations", integration: true do
+  describe "UploadDocumentWithAssociations" do
     it "executes succesfully when pointed at VBMS" do
       Tempfile.open("tmp") do |t|
         request = VBMS::Requests::UploadDocumentWithAssociations.new(
@@ -38,7 +38,7 @@ describe VBMS::Requests do
   end
 
   describe "ListDocuments" do
-    it "executes succesfully when pointed at VBMS", integration: true do
+    it "executes succesfully when pointed at VBMS" do
       request = VBMS::Requests::ListDocuments.new("784449089")
 
       setup_webmock(@client.endpoint_url, 'list_documents', 'listDocumentsResponse')
@@ -47,7 +47,7 @@ describe VBMS::Requests do
   end
 
   describe "FetchDocumentById" do
-    it "executes succesfully when pointed at VBMS", integration: true do
+    it "executes succesfully when pointed at VBMS" do
       # Use ListDocuments to find a document to fetch
       setup_webmock(@client.endpoint_url, 'list_documents2', 'listDocumentsResponse')
       request = VBMS::Requests::ListDocuments.new("784449089")
@@ -60,7 +60,7 @@ describe VBMS::Requests do
   end
 
   describe "GetDocumentTypes" do
-    it "executes succesfully when pointed at VBMS", integration: true do
+    it "executes succesfully when pointed at VBMS" do
       request = VBMS::Requests::GetDocumentTypes.new()
 
       setup_webmock(@client.endpoint_url, 'get_document_types', 'getDocumentTypesResponse')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,10 @@ def fixture(path)
 end
 
 def setup_webmock(endpoint_url, response_file, request_name)
-  return if ENV.key?('CONNECT_VBMS_RUN_EXTERNAL_TESTS')
+  if ENV.key?('CONNECT_VBMS_RUN_EXTERNAL_TESTS')
+    puts 'WARNING: the tests will be connecting to the live VBMS test server'
+    return
+  end
 
   require 'webmock/rspec'
   response_path = fixture_path("requests/#{response_file}.xml")
@@ -62,11 +65,5 @@ RSpec.configure do |config|
     # unless a formatter has already been configured
     # (e.g. via a command-line flag).
     config.default_formatter = :documentation
-  end
-
-  # If CONNECT_VBMS_KEYFILE is not set, don't run the integration tests
-  if ENV.key?('CONNECT_VBMS_RUN_EXTERNAL_TESTS') && !ENV.key?('CONNECT_VBMS_KEYFILE')
-    puts '¡¡¡ CONNECT_VBMS_KEYFILE is not set, not running integration tests!!!'
-    config.filter_run_excluding integration: true
   end
 end


### PR DESCRIPTION
* We should never skip the integration tests any more, so remove the integration attribute as it's unnecessary
* We shouldn't check for keyfile any longer, as we have the more direct `CONNECT_VBMS_RUN_EXTERNAL_TESTS` attribute
* Print a warning when connecting to the live VBMS test server