### PR TITLE
Convert several structs into full Ruby models

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,7 @@ Connect VBMS works by creating request objects, which are pure-data objects to
 represent the set of parameters an API call takes. These request objects are
 then passed to the client for execution.
 
-For ``ListDocuments``, the result is a list of ``VBMS::Document`` objects. For
+For ``ListDocuments``, the result is a list of ``VBMS::Responses::Document`` objects. For
 full details on ``ListDocuments`` and all the other API requests, consult the
 :doc:`API requests documentation <requests>`.
 

--- a/docs/requests.rst
+++ b/docs/requests.rst
@@ -16,7 +16,7 @@ file.
 Result
 ~~~~~~
 
-An ``Array`` of ``VBMS::Document`` objects.
+An ``Array`` of ``VBMS::Responses::Document`` objects.
 
 ``FetchDocumentById``
 ---------------------
@@ -31,7 +31,7 @@ identifier.
 Result
 ~~~~~~
 
-A ``VBMS::DocumentWithContent``.
+A ``VBMS::Responses::DocumentWithContent``.
 
 ``GetDocumentTypes``
 --------------------
@@ -46,7 +46,7 @@ supports.
 Result
 ~~~~~~
 
-An ``Array`` of ``VBMS::DocumentType``.
+An ``Array`` of ``VBMS::Responses::DocumentType``.
 
 ``UploadDocumentWithAssociations``
 ----------------------------------
@@ -64,8 +64,8 @@ An ``Array`` of ``VBMS::DocumentType``.
 Responses
 =========
 
-``VBMS::Document``
-------------------
+``VBMS::Responses::Document``
+-----------------------------
 
 Attributes
 ~~~~~~~~~~
@@ -76,17 +76,17 @@ Attributes
 * ``source`` (``String``): where this document came from.
 * ``received_at`` (``Date`` or ``nil``): when the VA received this document.
 
-``VBMS::DocumentWithContent``
------------------------------
+``VBMS::Responses::DocumentWithContent``
+----------------------------------------
 
 Attributes
 ~~~~~~~~~~
 
-* ``document`` (``VBMS::Document``)
+* ``document`` (``VBMS::Responses::Document``)
 * ``content`` (``String``): the contents of the file
 
-``VBMS::DocumentType``
-----------------------
+``VBMS::Responses::DocumentType``
+---------------------------------
 
 Attributes
 ~~~~~~~~~~

--- a/spec/requests/fetch_document_by_id_spec.rb
+++ b/spec/requests/fetch_document_by_id_spec.rb
@@ -24,7 +24,7 @@ describe VBMS::Requests::FetchDocumentById do
     subject { @response }
 
     it 'should return a DocumentWithContent object' do
-      expect(subject).to be_a(VBMS::DocumentWithContent)
+      expect(subject).to be_a(VBMS::Responses::DocumentWithContent)
     end
 
     it 'has valid document information' do

--- a/spec/requests/get_document_types_spec.rb
+++ b/spec/requests/get_document_types_spec.rb
@@ -25,7 +25,7 @@ describe VBMS::Requests::GetDocumentTypes do
 
     it 'should return an array of DocumentType objects' do
       expect(subject).to be_an(Array)
-      expect(subject).to all(be_a(VBMS::DocumentType))
+      expect(subject).to all(be_a(VBMS::Responses::DocumentType))
       expect(subject.count).to eq(512)
     end
 

--- a/spec/requests/list_documents_spec.rb
+++ b/spec/requests/list_documents_spec.rb
@@ -25,7 +25,7 @@ describe VBMS::Requests::ListDocuments do
 
     it 'should return an array of Document objects' do
       expect(subject).to be_an(Array)
-      expect(subject).to all(be_a(VBMS::Document))
+      expect(subject).to all(be_a(VBMS::Responses::Document))
       expect(subject.count).to eq(179) # how many are in sample file
     end
 

--- a/spec/responses/document_spec.rb
+++ b/spec/responses/document_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe VBMS::Responses::Document do
+  describe 'create_from_xml' do
+    let(:xml_string) { File.open(fixture_path('requests/fetch_document.xml')).read }
+    let(:xml) { Nokogiri::XML(xml_string) }
+    let(:doc) { xml.at_xpath('//v4:document', VBMS::XML_NAMESPACES) }
+
+    subject { VBMS::Responses::Document.create_from_xml(doc) }
+
+    specify { expect(subject.document_id).to eq('{9E364101-AFDD-49A7-A11F-602CCF2E5DB5}') }
+    specify { expect(subject.filename).to eq('tmp20150506-94244-6zotzp') }
+    specify { expect(subject.doc_type).to eq('356') }
+    specify { expect(subject.source).to eq('VHA_CUI') }
+    specify { expect(subject.mime_type).to eq('text/plain') }
+    specify { expect(subject.received_at).to eq(Date.parse('2015-05-06')) }
+  end
+end

--- a/spec/responses/document_type_spec.rb
+++ b/spec/responses/document_type_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe VBMS::Responses::DocumentType do
+  describe 'create_from_xml' do
+    let(:xml_string) { File.open(fixture_path('requests/get_document_types.xml')).read }
+    let(:xml) { Nokogiri::XML(xml_string) }
+    let(:doc) { xml.at_xpath('//v4:result', VBMS::XML_NAMESPACES) }
+
+    subject { VBMS::Responses::DocumentType.create_from_xml(doc) }
+
+    specify { expect(subject.type_id).to eq('431') }
+    specify { expect(subject.description).to eq('VA 21-4706c Court Appointed Fiduciarys Accounting') }
+  end
+end

--- a/spec/responses/document_with_content_spec.rb
+++ b/spec/responses/document_with_content_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe VBMS::Responses::DocumentWithContent do
+  describe 'create_from_xml' do
+    let(:xml) { Nokogiri::XML(File.open(fixture_path('requests/fetch_document.xml'))) }
+    let(:doc) { xml.at_xpath('//v4:result', VBMS::XML_NAMESPACES) }
+
+    subject { VBMS::Responses::DocumentWithContent.create_from_xml(doc) }
+
+    specify { expect(subject.document).to be_a(VBMS::Responses::Document) }
+    specify { expect(subject.content).to be_a(String) }
+
+    describe 'the associated document' do
+      specify { expect(subject.document.document_id).to eq('{9E364101-AFDD-49A7-A11F-602CCF2E5DB5}') }
+      specify { expect(subject.document.filename).to eq('tmp20150506-94244-6zotzp') }
+      specify { expect(subject.document.doc_type).to eq('356') }
+      specify { expect(subject.document.source).to eq('VHA_CUI') }
+      specify { expect(subject.document.mime_type).to eq('text/plain') }
+      specify { expect(subject.document.received_at).to eq(Date.parse('2015-05-06')) }
+    end
+  end
+end

--- a/src/vbms.rb
+++ b/src/vbms.rb
@@ -13,6 +13,10 @@ require 'vbms/client'
 require 'vbms/version'
 require 'vbms/requests'
 
+require 'vbms/responses/document'
+require 'vbms/responses/document_type'
+require 'vbms/responses/document_with_content'
+
 require 'vbms/requests/upload_document_with_associations'
 require 'vbms/requests/list_documents'
 require 'vbms/requests/fetch_document_by_id'

--- a/src/vbms/common.rb
+++ b/src/vbms/common.rb
@@ -47,15 +47,6 @@ module VBMS
     end
   end
 
-  DocumentType = Struct.new('DocumentType', :type_id, :description)
-  Document = Struct.new('Document',
-                        :document_id,
-                        :filename,
-                        :doc_type,
-                        :source,
-                        :received_at)
-  DocumentWithContent = Struct.new('DocumentWithContent', :document, :content)
-
   private
 
   def self.load_erb(path)

--- a/src/vbms/requests/fetch_document_by_id.rb
+++ b/src/vbms/requests/fetch_document_by_id.rb
@@ -25,31 +25,13 @@ module VBMS
         false
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def handle_response(doc)
         el = doc.at_xpath(
           '//v4:fetchDocumentResponse/v4:result', VBMS::XML_NAMESPACES
         )
-        document_el = el.at_xpath(
-          '//v4:document', VBMS::XML_NAMESPACES
-        )
-        received_date = document_el.at_xpath(
-          '//ns2:receivedDt/text()', VBMS::XML_NAMESPACES
-        )
-        VBMS::DocumentWithContent.new(
-          VBMS::Document.new(
-            document_el['id'],
-            document_el['filename'],
-            document_el['docType'],
-            document_el['source'],
-            received_date.nil? ? nil : Time.parse(received_date.content).to_date
-          ),
-          Base64.decode64(el.at_xpath(
-            '//v4:content/ns2:data/text()', VBMS::XML_NAMESPACES
-          ).content)
-        )
+
+        VBMS::Responses::DocumentWithContent.create_from_xml(el)
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
     end
   end
 end

--- a/src/vbms/requests/get_document_types.rb
+++ b/src/vbms/requests/get_document_types.rb
@@ -19,10 +19,7 @@ module VBMS
         doc.xpath(
           '//v4:getDocumentTypesResponse/v4:result', VBMS::XML_NAMESPACES
         ).map do |el|
-          DocumentType.new(
-            el['id'],
-            el['description']
-          )
+          VBMS::Responses::DocumentType.create_from_xml(el)
         end
       end
     end

--- a/src/vbms/requests/list_documents.rb
+++ b/src/vbms/requests/list_documents.rb
@@ -29,16 +29,7 @@ module VBMS
         doc.xpath(
           '//v4:listDocumentsResponse/v4:result', VBMS::XML_NAMESPACES
         ).map do |el|
-          received_date = el.at_xpath(
-            'ns2:receivedDt/text()', VBMS::XML_NAMESPACES
-          )
-          VBMS::Document.new(
-            el['id'],
-            el['filename'],
-            el['docType'],
-            el['source'],
-            received_date.nil? ? nil : Time.parse(received_date.content).to_date
-          )
+          VBMS::Responses::Document.create_from_xml(el)
         end
       end
     end

--- a/src/vbms/responses/document.rb
+++ b/src/vbms/responses/document.rb
@@ -1,0 +1,27 @@
+module VBMS
+  module Responses
+    class Document
+      attr_accessor :document_id, :filename, :doc_type, :source, :received_at, :mime_type
+  
+      def initialize(document_id: nil, filename: nil, doc_type: nil, source: nil, received_at: nil, mime_type: nil)
+        self.document_id = document_id
+        self.filename = filename
+        self.doc_type = doc_type
+        self.source = source
+        self.received_at = received_at
+        self.mime_type = mime_type
+      end
+  
+      def self.create_from_xml(el)
+        received_date = el.at_xpath('ns2:receivedDt/text()', VBMS::XML_NAMESPACES)
+        
+        new(document_id: el['id'],
+            filename: el['filename'],
+            doc_type: el['docType'],
+            source: el['source'],
+            mime_type: el['mimeType'],
+            received_at: received_date.nil? ? nil : Time.parse(received_date.content).to_date)
+      end
+    end
+  end
+end

--- a/src/vbms/responses/document_type.rb
+++ b/src/vbms/responses/document_type.rb
@@ -1,0 +1,17 @@
+module VBMS
+  module Responses
+    class DocumentType
+      attr_accessor :type_id, :description
+  
+      def initialize(type_id: nil, description: nil)
+        self.type_id = type_id
+        self.description = description
+      end
+  
+      def self.create_from_xml(el)
+        new(type_id: el['id'],
+            description: el['description'])
+      end
+    end
+  end
+end

--- a/src/vbms/responses/document_with_content.rb
+++ b/src/vbms/responses/document_with_content.rb
@@ -1,0 +1,19 @@
+module VBMS
+  module Responses
+    class DocumentWithContent
+      attr_accessor :document, :content
+  
+      def initialize(document: nil, content: nil)
+        self.document = document
+        self.content = content
+      end
+  
+      def self.create_from_xml(el)
+        document_el = el.at_xpath('//v4:document', VBMS::XML_NAMESPACES)
+  
+        new(document: Document.create_from_xml(document_el),
+            content: Base64.decode64(el.at_xpath('//v4:content/ns2:data/text()', VBMS::XML_NAMESPACES).content))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Turn the Document, DocumentType and DocumentwithContent into full-fledged Ruby classes instead of Struct declarations. The main point of this exercise is to define methods for parsing these objects from XML, so that logic for deserializing Documents from XML nodes is not duplicated in several places like it is now. It also makes the unit tests simple for these objects.

This addresses one of the issues highlighted in Issue #29
