### PR TITLE
Add information about environment variables to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # connect_vbms
 
-Connect VBMS is a Ruby gem for communicating with the Veteran Benefits Management System at the Department of Veteran Affairs. Although the source code is open source, access to VBMS is restricted only to authorized users.
+Connect VBMS is a Ruby gem for communicating with version 4 of the eDocumentService API provided by Veteran Benefits Management System (VBMS) at the Department of Veteran Affairs. Although the source code is open source, access to VBMS is restricted only to authorized users.
 
 ![](https://travis-ci.org/department-of-veterans-affairs/connect_vbms.svg?branch=master)
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Every other time, just run the below from the root directory:
 
 This will run all the tests and also runs [rubocop](http://batsov.com/rubocop/) to identify any stylistic problems in the code. You must ensure your code passes all tests and has no Rubocop violations before submitting a pull request.
 
+Tests normally mock all web requests so tests can be run without needing any credentials for VBMS systems. To run the integration tests against a VBMS server, you must specify all the necessary `VBMS_CONNECT` environment variables. You can then execute tests with `CONNECT_VBMS_RUN_EXTERNAL_TESTS=1 bundle exec rake default` and it will not use local webmocks.
+
 ## Docs
 
 From the root directory, run:

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # connect_vbms
 
-Connect VBMS is a Ruby library for connecting to VBMS.
+Connect VBMS is a Ruby gem for communicating with the Veteran Benefits Management System at the Department of Veteran Affairs. Although the source code is open source, access to VBMS is restricted only to authorized users.
 
 ![](https://travis-ci.org/department-of-veterans-affairs/connect_vbms.svg?branch=master)
 
 ## Prerequisites
 
+- Ruby 2.2 or above
+	- Bundler 1.10 or above (`gem install bundle`)
 - [Java JDK 1.7 or above](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 - [Python 2.6 or above](https://www.python.org/downloads/)
 	- Sphinx 1.3.1 or above (`pip install sphinx`)
-- Ruby 2.2 or above
-	- Bundler 1.10 or above (`gem install bundle`)
+
+The library currently uses Java for some encryption functionality. When this is replaced, the integration tests will continue to use the Java encryption/decryption utilities as a reference to check against. Python is currently used to generate documentation.
 
 ## Build
 
@@ -26,9 +28,9 @@ For the first run of the tests, install the Ruby dependencies:
 
 Every other time, just run the below from the root directory:
 
-`bundle exec rspec`
+`bundle exec rake default`
 
-The tests are dependent on your network and on the VBMS test server being up and running.
+This will run all the tests and also runs [rubocop](http://batsov.com/rubocop/) to identify any stylistic problems in the code. You must ensure your code passes all tests and has no Rubocop violations before submitting a pull request.
 
 ## Docs
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,12 +7,11 @@ To get started, you'll first need to get credentials from the VBMS team.
 You'll also need to make sure you have ``javac`` installed (version 1.7 or higher), and run
 ``rake build`` in the root of the Connect VBMS repo to build a gem in the ``pkg`` dir.
 
-Once you have credentials for VBMS, you can dive in:
+To connect to VBMS, you must be supplied credentials by the administrators. These credentials take the form of several files used for encrypting and authenticating messages between your client and the VBMS endpoint. These credentials will vary depending on which VBMS endpoint you are connecting to. This gem is designed to work only with ``v4`` of the ``eDocumentService`` VBMS API, so you must verify the URL of your endpoint is correct for that service.
 
 .. code-block:: ruby
 
     require 'vbms'
-
     client = VBMS::Client.new(
         '<endpoint URL for the environment you want to access>',
         '<path to key store>',
@@ -22,6 +21,32 @@ Once you have credentials for VBMS, you can dive in:
         '<path to CA certificate, or nil>',
         '<path to client certificate, or nil>',
     )
+
+ALternatively, you can set the values for these fields as environment variables. This approach is preferred since it avoids checking in any credentials to a repository and is one of the requirements for a proper `12-factor application`_ deployment. The environment variables that you must define are:
+
+.. _12-factor application: http://12factor.net/
+
+.. code-block:: zsh
+
+    CONNECT_VBMS_URL = '<endpoint URL for the environment you want to access>'
+    CONNECT_VBMS_ENV_DIR = '<path to directory where VBMS environments are found>'
+    CONNECT_VBMS_KEYFILE = '<relative path of the key store>'
+    CONNECT_VBMS_SAML = '<relative path of the SAML token>'
+    CONNECT_VBMS_KEYPASS = '<password for key store>'
+    CONNECT_VBMS_CACERT = '<path to CA certificate, or nil>'
+    CONNECT_VBMS_CERT = '<path to client certificate, or nil>''
+
+Note that the ``CONNECT_VBMS_ENV_DIR`` directory is the place where you put credentials for various environments. So, if you were to connect to the VBMS test environment, the keystore and SAML token must be placed in ``${CONNECT_VBMS_ENV_DIR}/test``. To create a Client object using environment variables in your Ruby code, use the ``Client#from_env_vars`` method:
+
+.. code-block:: ruby
+
+    require 'vbms'
+    client = VBMS::Client.from_env_vars(nil, 'test')
+
+The first argument allows you to pass in an optional Logger that will receive events and their data payloads, should you wish to audit that. The second argument is the environment to use the credentials for and defaults to ``test``. To ensure that these environment variables are properly loaded when you are developing your application, we recommend that you should use an automatic environment loader like Ruby's `dotenv`_ or Python's `autoenv`_.
+
+.. _dotenv: https://github.com/bkeepers/dotenv
+.. _autoenv: https://github.com/kennethreitz/autoenv
 
 Now you can issue a request, to list the contents of an eFolder:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ To connect to VBMS, you must be supplied credentials by the administrators. Thes
         '<path to client certificate, or nil>',
     )
 
-ALternatively, you can set the values for these fields as environment variables. This approach is preferred since it avoids checking in any credentials to a repository and is one of the requirements for a proper `12-factor application`_ deployment. The environment variables that you must define are:
+Alternatively, you can set the values for these fields as environment variables. This approach is preferred since it avoids checking in any credentials to a repository and is one of the requirements for a proper `12-factor application`_ deployment. The environment variables that you must define are:
 
 .. _12-factor application: http://12factor.net/
 

--- a/docs/requests.rst
+++ b/docs/requests.rst
@@ -74,6 +74,7 @@ Attributes
 * ``filename`` (``String``): the original filename of this document.
 * ``doc_type`` (``String``): the id for this document type.
 * ``source`` (``String``): where this document came from.
+* ``mime_type`` (``String``): the MIME type of the document.
 * ``received_at`` (``Date`` or ``nil``): when the VA received this document.
 
 ``VBMS::Responses::DocumentWithContent``


### PR DESCRIPTION
The main point of this pull request is to add some information about environment variables and the `Client#from_env_vars` constructor to the documentation. I also made a few other stylistic tweaks. Edits and feedback are always welcome. Do not merge into master until we decide this is no longer a WIP.

This pull request is in response to issue #3