### PR TITLE
Rename Client#send to #send_request

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Now you can issue a request, to list the contents of an eFolder:
 
     request = VBMS::Requests::ListDocuments.new("<file number>")
 
-    result = client.send(request)
+    result = client.send_request(request)
 
 Connect VBMS works by creating request objects, which are pure-data objects to
 represent the set of parameters an API call takes. These request objects are

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -66,7 +66,7 @@ describe VBMS::Client do
                                                       response_body: @response.body, 
                                                       request: @request)
 
-      @client.send(@request)
+      @client.send_request(@request)
     end
   end
 

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -36,7 +36,7 @@ describe VBMS::Requests do
         webmock_multipart_response(@client.endpoint_url,
                                    'upload_document_with_associations',
                                    'uploadDocumentWithAssociationsResponse')
-        @client.send(request)
+        @client.send_request(request)
 
         # other tests?
       end
@@ -48,7 +48,7 @@ describe VBMS::Requests do
       request = VBMS::Requests::ListDocuments.new('784449089')
 
       webmock_soap_response(@client.endpoint_url, 'list_documents', 'listDocumentsResponse')
-      @client.send(request)
+      @client.send_request(request)
     end
   end
 
@@ -59,11 +59,11 @@ describe VBMS::Requests do
       webmock_soap_response(@client.endpoint_url, 'list_documents', 'listDocumentsResponse')
 
       request = VBMS::Requests::ListDocuments.new('784449089')
-      result = @client.send(request)
+      result = @client.send_request(request)
 
       request = VBMS::Requests::FetchDocumentById.new(result[0].document_id)
       webmock_soap_response(@client.endpoint_url, 'fetch_document', 'fetchDocumentResponse')
-      @client.send(request)
+      @client.send_request(request)
     end
   end
 
@@ -72,7 +72,7 @@ describe VBMS::Requests do
       request = VBMS::Requests::GetDocumentTypes.new
 
       webmock_soap_response(@client.endpoint_url, 'get_document_types', 'getDocumentTypesResponse')
-      result = @client.send(request)
+      result = @client.send_request(request)
 
       expect(result).not_to be_empty
 

--- a/src/vbms/client.rb
+++ b/src/vbms/client.rb
@@ -52,7 +52,7 @@ module VBMS
     end
 
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-    def send(request)
+    def send_request(request)
       unencrypted_xml = request.render_xml
 
       log(
@@ -95,6 +95,14 @@ module VBMS
       process_response(request, response)
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+    def send(request)
+      # the Gem::Deprecate method didn't work because this method was named send
+      msg = "NOTE: Client#send is deprecated and will be removed in version 1.0; use #send_request instead\n" \
+            "Client.send called from #{Gem.location_of_caller.join(':')}\n"
+      warn msg unless Gem::Deprecate.skip
+      send_request(request)
+    end
 
     def inject_saml(doc)
       saml_doc = Nokogiri::XML(File.read(@saml)).root


### PR DESCRIPTION
Adds a deprecation message to Client#send. Note that I couldn't just use Gem::Deprecation module to deprecate since that calls `send` which is why you don't name a method that I guess. Anyhow, I've just inlined the code for now. Did you want to set a deadline for when this method will be removed?

Fixes issue #61 