### PR TITLE
Add to_s and to_h methods to all Responses classes

### DIFF
--- a/spec/responses/document_spec.rb
+++ b/spec/responses/document_spec.rb
@@ -32,6 +32,14 @@ describe VBMS::Responses::Document do
       expect(subject.to_s).to be_a(String)
     end
 
+    it 'should contain the attributes in to_s' do
+      s = subject.to_s
+      expect(s).to include(attrs[:document_id])
+      expect(s).to include(attrs[:filename])
+      expect(s).to include(attrs[:doc_type])
+      expect(s).to include(attrs[:source])
+    end
+
     it 'should respond to inspect' do
       expect(subject.inspect).to eq(subject.to_s)
     end

--- a/spec/responses/document_spec.rb
+++ b/spec/responses/document_spec.rb
@@ -15,4 +15,25 @@ describe VBMS::Responses::Document do
     specify { expect(subject.mime_type).to eq('text/plain') }
     specify { expect(subject.received_at).to eq(Date.parse('2015-05-06')) }
   end
+
+  describe 'serialization' do
+    let(:attrs) do
+      { document_id: '{9E364101-AFDD-49A7-A11F-602CCF2E5DB5}', filename: 'tmp20150506-94244-6zotzp', 
+        doc_type: '356', source: 'VHA_CUI', mime_type: 'text/plan', received_at: Time.now }
+    end
+    subject { VBMS::Responses::Document.new(attrs) }
+
+    it 'should respond to to_h' do
+      expect(subject.to_h).to be_a(Hash)
+      expect(subject.to_h).to include(attrs)
+    end
+
+    it 'should respond to to_s' do
+      expect(subject.to_s).to be_a(String)
+    end
+
+    it 'should respond to inspect' do
+      expect(subject.inspect).to eq(subject.to_s)
+    end
+  end
 end

--- a/spec/responses/document_type_spec.rb
+++ b/spec/responses/document_type_spec.rb
@@ -11,4 +11,24 @@ describe VBMS::Responses::DocumentType do
     specify { expect(subject.type_id).to eq('431') }
     specify { expect(subject.description).to eq('VA 21-4706c Court Appointed Fiduciarys Accounting') }
   end
+
+  describe 'serialization' do
+    let(:attrs) do
+      { type_id: '431', description: 'VA 21-4706c Court Appointed Fiduciarys Accounting' }
+    end
+    subject { VBMS::Responses::DocumentType.new(attrs) }
+
+    it 'should respond to to_h' do
+      expect(subject.to_h).to be_a(Hash)
+      expect(subject.to_h).to include(attrs)
+    end
+
+    it 'should respond to to_s' do
+      expect(subject.to_s).to be_a(String)
+    end
+
+    it 'should respond to inspect' do
+      expect(subject.inspect).to eq(subject.to_s)
+    end
+  end
 end

--- a/spec/responses/document_type_spec.rb
+++ b/spec/responses/document_type_spec.rb
@@ -27,6 +27,12 @@ describe VBMS::Responses::DocumentType do
       expect(subject.to_s).to be_a(String)
     end
 
+    it 'should contain the attributes in to_s' do
+      s = subject.to_s
+      expect(s).to include(attrs[:type_id])
+      expect(s).to include(attrs[:description])
+    end
+
     it 'should respond to inspect' do
       expect(subject.inspect).to eq(subject.to_s)
     end

--- a/spec/responses/document_with_content_spec.rb
+++ b/spec/responses/document_with_content_spec.rb
@@ -19,4 +19,24 @@ describe VBMS::Responses::DocumentWithContent do
       specify { expect(subject.document.received_at).to eq(Date.parse('2015-05-06')) }
     end
   end
+
+  describe 'serialization' do
+    let(:document) { VBMS::Responses::Document.new }
+    let(:content) { 'foo' }
+    let(:attrs) { { document: document, content: content } }
+    subject { VBMS::Responses::DocumentWithContent.new(attrs) }
+
+    it 'should respond to to_h' do
+      expect(subject.to_h).to be_a(Hash)
+      expect(subject.to_h).to include(attrs)
+    end
+
+    it 'should respond to to_s' do
+      expect(subject.to_s).to be_a(String)
+    end
+
+    it 'should respond to inspect with same response as to_s' do
+      expect(subject.inspect).to eq(subject.to_s)
+    end
+  end
 end

--- a/spec/responses/document_with_content_spec.rb
+++ b/spec/responses/document_with_content_spec.rb
@@ -35,6 +35,10 @@ describe VBMS::Responses::DocumentWithContent do
       expect(subject.to_s).to be_a(String)
     end
 
+    it 'should contain the attributes in to_s' do
+      expect(subject.to_s).to include(content)
+    end
+
     it 'should respond to inspect with same response as to_s' do
       expect(subject.inspect).to eq(subject.to_s)
     end

--- a/src/vbms/responses/document.rb
+++ b/src/vbms/responses/document.rb
@@ -26,7 +26,7 @@ module VBMS
       def to_h
         # not using metaprogramming to keep it simple
         {
-          document_id: @document_id,
+          document_id: document_id,
           filename: filename,
           doc_type: doc_type,
           source: source,

--- a/src/vbms/responses/document.rb
+++ b/src/vbms/responses/document.rb
@@ -22,6 +22,20 @@ module VBMS
             mime_type: el['mimeType'],
             received_at: received_date.nil? ? nil : Time.parse(received_date.content).to_date)
       end
+
+      def to_h
+        # not using metaprogramming to keep it simple
+        {
+          document_id: @document_id,
+          filename: filename,
+          doc_type: doc_type,
+          source: source,
+          received_at: received_at,
+          mime_type: mime_type
+        }
+      end
+
+      alias_method :to_s, :inspect
     end
   end
 end

--- a/src/vbms/responses/document_type.rb
+++ b/src/vbms/responses/document_type.rb
@@ -12,6 +12,12 @@ module VBMS
         new(type_id: el['id'],
             description: el['description'])
       end
+
+      def to_h
+        { type_id: type_id, description: description }
+      end
+
+      alias_method :to_s, :inspect
     end
   end
 end

--- a/src/vbms/responses/document_with_content.rb
+++ b/src/vbms/responses/document_with_content.rb
@@ -14,6 +14,12 @@ module VBMS
         new(document: Document.create_from_xml(document_el),
             content: Base64.decode64(el.at_xpath('//v4:content/ns2:data/text()', VBMS::XML_NAMESPACES).content))
       end
+
+      def to_h
+        { document: document, content: content }
+      end
+
+      alias_method :to_s, :inspect
     end
   end
 end


### PR DESCRIPTION
I've added a `#to_h` method back to all of the `Responses` classes as well as mapping `to_s` to the already existing `inspect` methods. If you want something more specific for any of these, please let me know.

Fixes Issue #76