### PR TITLE
Updates the documentation to include proper Sphinx-linking

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -32,7 +32,7 @@ our feature branches in sync. All pull requests are community reviewed
 and must pass our continuous integration spec run and code style
 enforcer in `Travis CI`_.
 
-We have a pre-configured `Vagrant environment`_ which generates a fresh
+We have a pre-configured :doc:`Vagrant environment <developing_with_vagrant>` which generates a fresh
 Ubuntu development environment with all necessary dependencies.
 
 Example:
@@ -63,9 +63,35 @@ Example:
 
        git push origin feature/do_something_awesome
 
+Testing Your Work
+=================
+
+There are a number of tests and fixture files for this gem written in `rspec`_. When contributing new code, 
+please modify or write new tests to verify your code is functioning correctly. In addition, we expect all
+tests to comply with the `RuboCop`_ style guide conventions. To run tests and verify your code complies with
+our style rules, run the following rake tasks
+
+    ::
+
+        rake default
+
+And make sure it passes before submitting a pull request. Otherwise, your code will almost certainly fail within
+Travis CI.
+
+Tests normally mock all web requests so tests can be run without needing any credentials for VBMS systems. To run the integration tests against a VBMS server, you must specify all the necessary ``VBMS_CONNECT`` environment variables. You can then execute tests with 
+
+    ::
+
+        CONNECT_VBMS_RUN_EXTERNAL_TESTS=1 rake default
+
+and it will connect directly to the VBMS for all tests of remote communication. This can be useful for verifying that our mocks are still accurate samples of real VBMS responses.
+
+The encryption and decryption tests use a special test keystore file located in the ``spec/fixtures`` directory whose keys are only valid for a year or so. If your encryption tests suddenly start failing, see :doc:`the instructions for generating a new test keystore<generating_new_keystore>`.
+
 .. _CC0 1.0 Universal public domain dedication: https://creativecommons.org/publicdomain/zero/1.0/
 .. _release notes: https://github.com/department-of-veterans-affairs/connect_vbms/releases
 .. _semantic versioning: http://semver.org/
 .. _git flow: http://nvie.com/posts/a-successful-git-branching-model/
 .. _Travis CI: https://travis-ci.org/department-of-veterans-affairs/connect_vbms
-.. _Vagrant environment: https://github.com/department-of-veterans-affairs/connect_vbms/blob/master/docs/developing_with_vagrant.rst
+.. _rspec: http://rspec.info/
+.. _RuboCop: https://github.com/bbatsov/rubocop

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,7 +70,13 @@ Requests Documentation
 ----------------------
 
 For ``ListDocuments``, the result is a list of ``VBMS::Responses::Document`` objects. For
-full details on ``ListDocuments`` and all the other API requests, consult the `requests documentation`_.
+full details on ``ListDocuments`` and all the other API requests, consult :doc:`requests`
+
+Audit Logging
+-------------
+
+The ``VBMS::Client`` constructors accept an optional Logger argument. This is not the Ruby Logger but a class you define
+to respond to specific messages from the VBMS Client. For more details, see :doc:`logger`
 
 
 Contributing
@@ -79,25 +85,14 @@ Contributing
 Contributing Guide
 ==================
 
-View our `contributing guide`_ for information on contributing to this gem. 
+View :doc:`Contribution Guidelines <contributing>` for information on contributing to this gem. 
 
 Developing with Vagrant
 =======================
 
-View our `vagrant guide`_ for information on using our prebuilt Vagrant VM for development.
+View :doc:`developing_with_vagrant` for information on using our prebuilt Vagrant VM for development.
 
 Java Versions
 =============
 
-To build with a specific version of Java, use our `building java guide`_.
-
-----
-
-.. contents:: Table of Contents
-   :depth: 2
-
-
-.. _requests documentation: https://github.com/department-of-veterans-affairs/connect_vbms/blob/master/docs/requests.rst#api-requests
-.. _contributing guide: https://github.com/department-of-veterans-affairs/connect_vbms/blob/master/docs/contributing.rst
-.. _building java guide: https://github.com/department-of-veterans-affairs/connect_vbms/blob/master/docs/crosscompile_java.rst
-.. _vagrant guide: https://github.com/department-of-veterans-affairs/connect_vbms/blob/master/docs/developing_with_vagrant.rst
+To build with a specific version of Java, see :doc:`crosscompile_java`.


### PR DESCRIPTION
This commit changes a few things:
1. Change HTTP links to Github to internal Sphinx-format :doc: links
2. Add references to new pages for keystore and audit logging
3. Remove redundant TOC at bottom of the index page

This [reference on Sphinx linking syntax](http://sphinx-doc.org/markup/inline.html) was very helpful