### PR TITLE
Updated build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ The library currently uses Java for some encryption functionality. When this is 
 
 From the root directory, run:
 
-`rake build`
+```
+> bundle install
+> bundle exec rake build
+```
 
 ## Tests
 
@@ -50,4 +53,3 @@ Please read our [Contributing guide](https://github.com/department-of-veterans-a
 [The project is in the public domain](LICENSE.md), and all contributions will also be released in the public domain. By submitting a pull request, you are agreeing to waive all rights to your contribution under the terms of the [CC0 Public Domain Dedication](http://creativecommons.org/publicdomain/zero/1.0/).
 
 This project constitutes an original work of the United States Government.
-


### PR DESCRIPTION
The existing build instructions, that only say to `rake build`, fail with the following:

```
>rake build --trace
rake aborted!
LoadError: cannot load such file -- rubocop/rake_task
/Users/vacomaherj/.rvm/rubies/ruby-2.2.1/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
/Users/vacomaherj/.rvm/rubies/ruby-2.2.1/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
/Users/vacomaherj/GitHub/connect_vbms_cert/Rakefile:3:in `<top (required)>'
/Users/vacomaherj/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/rake/rake_module.rb:28:in `load'
/Users/vacomaherj/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/rake/rake_module.rb:28:in `load_rakefile'
/Users/vacomaherj/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/rake/application.rb:689:in `raw_load_rakefile'
/Users/vacomaherj/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/rake/application.rb:94:in `block in load_rakefile'
/Users/vacomaherj/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/rake/application.rb:176:in `standard_exception_handling'
/Users/vacomaherj/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/rake/application.rb:93:in `load_rakefile'
/Users/vacomaherj/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/rake/application.rb:77:in `block in run'
/Users/vacomaherj/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/rake/application.rb:176:in `standard_exception_handling'
/Users/vacomaherj/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/rake/application.rb:75:in `run'
/Users/vacomaherj/.rvm/rubies/ruby-2.2.1/bin/rake:33:in `<main>'
```

These instructions add downloading dependencies, then running rake via bundler such that the dependencies are included.