### PR TITLE
Add Establish Claim Request

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ task :build_java do
 end
 
 task :fixtures do
-  generate_test_creds()
+  generate_test_creds
 end
 
 task :docs do

--- a/connect_vbms.gemspec
+++ b/connect_vbms.gemspec
@@ -16,13 +16,12 @@ Gem::Specification.new do |spec|
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = ""
-  else
+  unless spec.respond_to?(:metadata)
     fail "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
 
-  git_files = `git ls-files -z`.split("\x00").reject { |f| f.match(%r{^(test|spec|features|\.java)/}) }
+  spec.metadata["allowed_push_host"] = ""
+
   # spec.files         = git_fiels + Dir['classes/*.class']
   # spec.require_paths = ['src']
 

--- a/lib/templates/request.erb
+++ b/lib/templates/request.erb
@@ -1,7 +1,1 @@
---boundary_1234
-Content-Type: application/xop+xml; type="application/soap+xml"; charset=utf-8
-
 <%= doc.to_s %>
-
-
---boundary_1234

--- a/lib/vbms.rb
+++ b/lib/vbms.rb
@@ -21,11 +21,14 @@ require "vbms/requests"
 require "vbms/responses/document"
 require "vbms/responses/document_type"
 require "vbms/responses/document_with_content"
+require "vbms/responses/claim"
 
+require "vbms/requests/base_request"
 require "vbms/requests/upload_document_with_associations"
 require "vbms/requests/list_documents"
 require "vbms/requests/fetch_document_by_id"
 require "vbms/requests/get_document_types"
+require "vbms/requests/establish_claim"
 
 # require 'xmldsig'
 require "xmldsig/signature_override"

--- a/lib/vbms/common.rb
+++ b/lib/vbms/common.rb
@@ -29,7 +29,13 @@ module VBMS
     wsse: "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd",
     wsu: "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd",
     ds: 'http://www.w3.org/2000/09/xmldsig#',
-    xenc: 'http://www.w3.org/2001/04/xmlenc#'
+    xenc: 'http://www.w3.org/2001/04/xmlenc#',
+    claimV4: "http://vbms.vba.va.gov/external/ClaimService/v4"
+  }.freeze
+
+  ENDPOINTS = {
+    claims: "/vbmsp2-cs/ClaimServiceV4",
+    efolder: "/vbmsp2-cms/streaming/eDocumentService-v4"
   }.freeze
 
   class ClientError < StandardError

--- a/lib/vbms/requests.rb
+++ b/lib/vbms/requests.rb
@@ -8,20 +8,12 @@ module VBMS
       "xmlns:xop" => "http://www.w3.org/2004/08/xop/include"
     }.freeze
 
-    def self.soap
+    def self.soap(more_namespaces: {})
       Nokogiri::XML::Builder.new do |xml|
-        xml["soapenv"].Envelope(VBMS::Requests::NAMESPACES) do
-          xml["soapenv"].Header
+        xml["soapenv"].Envelope(VBMS::Requests::NAMESPACES.merge(more_namespaces)) do
           xml["soapenv"].Body { yield(xml) }
         end
       end.doc
-    end
-
-    def self.body
-      Nokogiri::XML::Builder.new do |xml|
-        # xml['soapenv'].Body { yield(xml) }
-        yield xml
-      end
     end
   end
 end

--- a/lib/vbms/requests/base_request.rb
+++ b/lib/vbms/requests/base_request.rb
@@ -2,6 +2,10 @@ module VBMS
   module Requests
     # Abstract class providing defaults to some of the methods requried
     class BaseRequest
+      def multipart?
+        false
+      end
+
       def inject_header_content(xml)
         xml
       end

--- a/lib/vbms/requests/base_request.rb
+++ b/lib/vbms/requests/base_request.rb
@@ -1,0 +1,10 @@
+module VBMS
+  module Requests
+    # Abstract class providing defaults to some of the methods requried
+    class BaseRequest
+      def inject_header_content(xml)
+        xml
+      end
+    end
+  end
+end

--- a/lib/vbms/requests/establish_claim.rb
+++ b/lib/vbms/requests/establish_claim.rb
@@ -1,0 +1,107 @@
+module VBMS
+  module Requests
+    class EstablishClaim < BaseRequest
+      NAMESPACES = {
+        "xmlns:cla" => "http://vbms.vba.va.gov/external/ClaimService/v4",
+        "xmlns:cdm" => "http://vbms.vba.va.gov/cdm/claim/v4",
+        "xmlns:participant" => "http://vbms.vba.va.gov/cdm/participant/v4"
+      }.freeze
+
+      def initialize(veteran_record, claim)
+        validate(veteran_record, claim)
+
+        @veteran_record = veteran_record
+        @claim = claim
+      end
+
+      def name
+        "establishClaim"
+      end
+
+      def endpoint_url(base_url)
+        "#{base_url}#{VBMS::ENDPOINTS[:claims]}"
+      end
+
+      def inject_header_content(header_xml)
+        Nokogiri::XML::Builder.with(header_xml) do |xml|
+          xml["vbmsext"].userId("dslogon.1011239249", "xmlns:vbmsext" => "http://vbms.vba.va.gov/external")
+        end
+      end
+
+      # More information on what the fields mean, see:
+      # https://github.com/department-of-veterans-affairs/dsva-vbms/issues/66#issuecomment-266098034
+      def soap_doc
+        VBMS::Requests.soap(more_namespaces: NAMESPACES) do |xml|
+          xml["cla"].establishClaim do
+            xml["cla"].veteranInput(
+              "fileNumber" => @veteran_record[:file_number],
+              "gender" => @veteran_record[:sex],
+              "marriageStatus" => "Unknown"
+            ) do
+              xml["participant"].preferredName(
+                "firstName" => @veteran_record[:first_name],
+                "lastName" => @veteran_record[:last_name])
+
+              xml["participant"].personalInfo("ssn" => @veteran_record[:ssn]) do
+                xml["participant"].address(
+                  "addressLine1" => @veteran_record[:address_line1],
+                  "addressLine2" => @veteran_record[:address_line2],
+                  "addressLine3" => @veteran_record[:address_line3],
+                  "city" => @veteran_record[:city],
+                  "stateCode" => @veteran_record[:state],
+                  "countryCode" => @veteran_record[:country],
+                  "postalCode" => @veteran_record[:zip_code],
+                  "preferredAddr" => "true",
+                  "type" => ""
+                )
+              end
+            end
+
+            xml["cla"].claimToEstablish(
+              "benefitTypeCd" => @claim[:benefit_type_code], # C&P Live = '1', C&P Death = '2'
+              "claimLevelStatusCd" => "PEND",
+              "payeeCd" => @claim[:payee_code],
+              "label" => @claim[:end_product_label],
+              "modifiedEndProductCd" => @claim[:end_product_modifier],
+              "sectionUnit" => "999", # This number doesn't matter, but is required
+              "stationOfJurisdiction" => @claim[:station_of_jurisdiction],
+              "currentStationOfJurisdiction" => @claim[:station_of_jurisdiction],
+              "disposition" => "M",
+              "folderWithClaim" => "N",
+              "priority" => "1",
+              "preDischarge" => @claim[:predischarge] ? "true" : "false",
+              "gulfWarRegistry" => @claim[:gulf_war_registry] ? "true" : "false"
+            ) do
+              xml["cdm"].endProductClaimType(
+                "code" => @claim[:end_product_code],
+                "name" => @claim[:end_product_label]
+              )
+
+              xml["cdm"].claimDateDt @claim[:date].iso8601
+              xml["cdm"].suppressAckLetter @claim[:suppress_acknowledgment_letter]
+            end
+          end
+        end
+      end
+
+      def signed_elements
+        [["/soapenv:Envelope/soapenv:Body",
+          { soapenv: SoapScum::XMLNamespaces::SOAPENV },
+          "Content"]]
+      end
+
+      def multipart?
+        false
+      end
+
+      def handle_response(doc)
+        el = doc.at_xpath(
+          "//claimV4:establishClaimResponse/claimV4:establishedClaim",
+          VBMS::XML_NAMESPACES
+        )
+
+        VBMS::Responses::Claim.create_from_xml(el)
+      end
+    end
+  end
+end

--- a/lib/vbms/requests/establish_claim.rb
+++ b/lib/vbms/requests/establish_claim.rb
@@ -8,8 +8,6 @@ module VBMS
       }.freeze
 
       def initialize(veteran_record, claim)
-        validate(veteran_record, claim)
-
         @veteran_record = veteran_record
         @claim = claim
       end

--- a/lib/vbms/requests/establish_claim.rb
+++ b/lib/vbms/requests/establish_claim.rb
@@ -88,10 +88,6 @@ module VBMS
           "Content"]]
       end
 
-      def multipart?
-        false
-      end
-
       def handle_response(doc)
         el = doc.at_xpath(
           "//claimV4:establishClaimResponse/claimV4:establishedClaim",

--- a/lib/vbms/requests/fetch_document_by_id.rb
+++ b/lib/vbms/requests/fetch_document_by_id.rb
@@ -1,12 +1,16 @@
 module VBMS
   module Requests
-    class FetchDocumentById
+    class FetchDocumentById < BaseRequest
       def initialize(document_id)
         @document_id = document_id
       end
 
       def name
         "fetchDocumentById"
+      end
+
+      def endpoint_url(base_url)
+        "#{base_url}#{VBMS::ENDPOINTS[:efolder]}"
       end
 
       def soap_doc

--- a/lib/vbms/requests/fetch_document_by_id.rb
+++ b/lib/vbms/requests/fetch_document_by_id.rb
@@ -27,10 +27,6 @@ module VBMS
           "Content"]]
       end
 
-      def multipart?
-        false
-      end
-
       def handle_response(doc)
         el = doc.at_xpath(
           "//v4:fetchDocumentResponse/v4:result", VBMS::XML_NAMESPACES

--- a/lib/vbms/requests/get_document_types.rb
+++ b/lib/vbms/requests/get_document_types.rb
@@ -25,10 +25,6 @@ module VBMS
           "Content"]]
       end
 
-      def multipart?
-        false
-      end
-
       def handle_response(doc)
         doc.xpath(
           "//v4:getDocumentTypesResponse/v4:result", VBMS::XML_NAMESPACES

--- a/lib/vbms/requests/get_document_types.rb
+++ b/lib/vbms/requests/get_document_types.rb
@@ -1,6 +1,6 @@
 module VBMS
   module Requests
-    class GetDocumentTypes
+    class GetDocumentTypes < BaseRequest
       def name
         "getDocumentTypes"
       end
@@ -9,6 +9,14 @@ module VBMS
         VBMS::Requests.soap do |xml|
           xml["v4"].getDocumentTypes
         end
+      end
+
+      def inject_header_content(xml)
+        xml
+      end
+
+      def endpoint_url(base_url)
+        "#{base_url}#{VBMS::ENDPOINTS[:efolder]}"
       end
 
       def signed_elements

--- a/lib/vbms/requests/list_documents.rb
+++ b/lib/vbms/requests/list_documents.rb
@@ -27,10 +27,6 @@ module VBMS
           "Content"]]
       end
 
-      def multipart?
-        false
-      end
-
       def handle_response(doc)
         doc.xpath(
           "//v4:listDocumentsResponse/v4:result", VBMS::XML_NAMESPACES

--- a/lib/vbms/requests/list_documents.rb
+++ b/lib/vbms/requests/list_documents.rb
@@ -1,12 +1,16 @@
 module VBMS
   module Requests
-    class ListDocuments
+    class ListDocuments < BaseRequest
       def initialize(file_number)
         @file_number = file_number
       end
 
       def name
         "listDocuments"
+      end
+
+      def endpoint_url(base_url)
+        "#{base_url}#{VBMS::ENDPOINTS[:efolder]}"
       end
 
       def soap_doc

--- a/lib/vbms/requests/upload_document_with_associations.rb
+++ b/lib/vbms/requests/upload_document_with_associations.rb
@@ -1,6 +1,6 @@
 module VBMS
   module Requests
-    class UploadDocumentWithAssociations
+    class UploadDocumentWithAssociations < BaseRequest
       attr_reader :file_number
 
       def initialize(file_number, received_at, first_name, middle_name,
@@ -19,6 +19,10 @@ module VBMS
 
       def name
         "uploadDocumentWithAssociations"
+      end
+
+      def endpoint_url(base_url)
+        "#{base_url}#{VBMS::ENDPOINTS[:efolder]}"
       end
 
       # received_date returns a string representing the date the document was

--- a/lib/vbms/responses/claim.rb
+++ b/lib/vbms/responses/claim.rb
@@ -1,0 +1,15 @@
+module VBMS
+  module Responses
+    class Claim
+      attr_accessor :claim_id
+  
+      def initialize(claim_id: nil)
+        self.claim_id = claim_id
+      end
+  
+      def self.create_from_xml(el)
+        new(claim_id: el["id"])
+      end
+    end
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -41,11 +41,16 @@ describe VBMS::Client do
                         source: "CUI tests",
                         name: "uploadDocumentWithAssociations",
                         new_mail: "",
+                        multipart?: false,
                         soap_doc:  VBMS::Requests.soap { "body" },
                         signed_elements: [["/soapenv:Envelope/soapenv:Body",
                                            { soapenv: SoapScum::XMLNamespaces::SOAPENV },
                                            "Content"]]
                        )
+
+      @request.should_receive(:inject_header_content)
+      @request.should_receive(:endpoint_url)
+
       @response = double("response", code: 200, body: "response")
     end
 

--- a/spec/fixtures/requests/establish_claim.xml
+++ b/spec/fixtures/requests/establish_claim.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<S:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
+  <env:Header>
+  </env:Header>
+  <S:Body xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="id-462">
+    <establishClaimResponse xmlns="http://vbms.vba.va.gov/external/ClaimService/v4" xmlns:S="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns0="http://vbms.vba.va.gov/cdm/claim/v4" xmlns:ns1="http://vbms.vba.va.gov/cdm/common/v4" xmlns:ns2="http://vbms.vba.va.gov/cdm/participant/v4"><establishedClaim benefitTypeCd="CPL" claimLevelStatusCd="PEND" currentStationOfJurisdiction="317" gulfWarRegistry="false" id="600091508" label="AMC-Cert to BVA" modifiedEndProductCd="071" participantPersonId="600113642" payeeCd="00" preDischarge="false" priority="unknown" sectionUnit="123725" stationOfJurisdiction="499" suspenseReasonCd="062" veteranPersonId="600113642"><ns0:endProductClaimType code="070CERT2AMC" name="AMC-Cert to BVA"/><ns0:claimDateDt>2016-12-10-05:00</ns0:claimDateDt><ns0:suspenseDate>2017-01-09-05:00</ns0:suspenseDate><ns0:suppressAckLetter>false</ns0:suppressAckLetter><ns0:futureReason>Pending Initial Development - Std 5103 Notice Not Required</ns0:futureReason></establishedClaim></establishClaimResponse>
+  </S:Body>
+</S:Envelope>

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -27,12 +27,10 @@ describe VBMS::Requests do
           true
         )
 
-        webmock_multipart_response(@client.endpoint_url,
+        webmock_multipart_response("#{@client.base_url}#{VBMS::ENDPOINTS[:efolder]}",
                                    "upload_document_with_associations",
                                    "uploadDocumentWithAssociationsResponse")
         @client.send_request(request)
-
-        # other tests?
       end
     end
   end
@@ -41,7 +39,7 @@ describe VBMS::Requests do
     it "executes succesfully when pointed at VBMS" do
       request = VBMS::Requests::ListDocuments.new("784449089")
 
-      webmock_soap_response(@client.endpoint_url, "list_documents", "listDocumentsResponse")
+      webmock_soap_response("#{@client.base_url}#{VBMS::ENDPOINTS[:efolder]}", "list_documents", "listDocumentsResponse")
       @client.send_request(request)
     end
   end
@@ -50,13 +48,15 @@ describe VBMS::Requests do
     it "executes succesfully when pointed at VBMS" do
       # Use ListDocuments to find a document to fetch
 
-      webmock_soap_response(@client.endpoint_url, "list_documents", "listDocumentsResponse")
+      webmock_soap_response("#{@client.base_url}#{VBMS::ENDPOINTS[:efolder]}", "list_documents", "listDocumentsResponse")
 
       request = VBMS::Requests::ListDocuments.new("784449089")
       result = @client.send_request(request)
 
       request = VBMS::Requests::FetchDocumentById.new(result[0].document_id)
-      webmock_soap_response(@client.endpoint_url, "fetch_document", "fetchDocumentResponse")
+      webmock_soap_response("#{@client.base_url}#{VBMS::ENDPOINTS[:efolder]}", 
+                            "fetch_document",
+                            "fetchDocumentResponse")
       @client.send_request(request)
     end
   end
@@ -65,13 +65,64 @@ describe VBMS::Requests do
     it "executes succesfully when pointed at VBMS" do
       request = VBMS::Requests::GetDocumentTypes.new
 
-      webmock_soap_response(@client.endpoint_url, "get_document_types", "getDocumentTypesResponse")
+      webmock_soap_response("#{@client.base_url}#{VBMS::ENDPOINTS[:efolder]}",
+                            "get_document_types",
+                            "getDocumentTypesResponse")
       result = @client.send_request(request)
 
       expect(result).not_to be_empty
 
       expect(result[0].type_id).to be_a_kind_of(String)
       expect(result[0].description).to be_a_kind_of(String)
+    end
+  end
+
+  describe "EstablishClaim" do
+    let(:veteran_record) do
+      {
+        file_number: "561349920",
+        sex: "M",
+        first_name: "Stan",
+        last_name: "Stanman",
+        ssn: "796164121",
+        address_line1: "Shrek's Swamp",
+        address_line2: "",
+        address_line3: "",
+        city: "Charleston",
+        state: "SC",
+        country: "USA",
+        zip_code: "29401"
+      }
+    end
+
+    # NOTE: In order for this to pass when connected to VBMS
+    # the information here cannot be a duplicate of an existing
+    # claim. The easiest way to do this is to increment the `end_product_modifier`
+    let(:claim) do
+      {
+        benefit_type_code: "1",
+        payee_code: "00",
+        station_of_jurisdiction: "317",
+        end_product_code: "070CERT2AMC",
+        end_product_modifier: "071",
+        end_product_label: "AMC-Cert to BVA",
+        predischarge: false,
+        gulf_war_registry: false,
+        date: 20.days.ago.to_date,
+        suppress_acknowledgment_letter: false
+      }
+    end
+
+    it "executes succesfully when pointed at VBMS" do
+      request = VBMS::Requests::EstablishClaim.new(veteran_record, claim)
+
+      webmock_soap_response("#{@client.base_url}#{VBMS::ENDPOINTS[:claims]}",
+                            "establish_claim",
+                            "establishedClaim")
+
+      result = @client.send_request(request)
+
+      expect(result.claim_id).to be_a_kind_of(String)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -151,7 +151,7 @@ end
 
 def new_test_client
   VBMS::Client.new(
-    endpoint_url: "http://test.endpoint.url/",
+    base_url: "http://test.endpoint.url/",
     keypass: "importkey",
     client_keyfile: fixture_path("test_client.p12"),
     server_cert: fixture_path("test_server.crt"),


### PR DESCRIPTION
Since the URL for this endpoint is different for the eFolder endpoints, it
requires the use of `CONNECT_VBMS_BASE_URL` environment variable instead of
`CONNECT_VBMS_URL`.

fixes #122