### PR TITLE
Anya/upload document

### DIFF
--- a/lib/soap_scum/ws_security.rb
+++ b/lib/soap_scum/ws_security.rb
@@ -52,6 +52,9 @@ module SoapScum
         verify_header_node(soap_doc)
         add_timestamp_node(soap_doc)
 
+        # Double encryption must not be used on operations uploadDocument and updateDocument.
+        return soap_doc if nodes.empty?
+
         Nokogiri::XML::Builder.with(soap_doc.at("/soap:Envelope/soap:Header/wsse:Security",
                                                 soap: XMLNamespaces::SOAPENV,
                                                 "xmlns:wsse" => XMLNamespaces::WSSE,

--- a/lib/vbms.rb
+++ b/lib/vbms.rb
@@ -34,6 +34,8 @@ require "vbms/requests/establish_claim"
 # eFolder Service 1.0
 require "vbms/requests/find_document_series_reference"
 require "vbms/requests/get_document_content"
+require "vbms/requests/initialize_upload"
+require "vbms/requests/upload_document"
 
 require "vbms/helpers/xml_helper"
 

--- a/lib/vbms/common.rb
+++ b/lib/vbms/common.rb
@@ -25,7 +25,8 @@ module VBMS
   XML_NAMESPACES = {
     v4: "http://vbms.vba.va.gov/external/eDocumentService/v4",
     ns2: "http://vbms.vba.va.gov/cdm/document/v4",
-    efol: "http://service.efolder.vbms.vba.va.gov/eFolderReadService",
+    upload: "http://service.efolder.vbms.vba.va.gov/eFolderUploadService",
+    read: "http://service.efolder.vbms.vba.va.gov/eFolderReadService",
     v5: "http://vbms.vba.va.gov/cdm/document/v5",
     soapenv: "http://schemas.xmlsoap.org/soap/envelope/",
     wsse: "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd",

--- a/lib/vbms/helpers/xml_helper.rb
+++ b/lib/vbms/helpers/xml_helper.rb
@@ -26,4 +26,8 @@ module XMLHelper
   def self.most_recent_version(versions)
     versions.is_a?(Array) ? versions.sort_by { |v| v[:version][:@major].to_i }.last : versions
   end
+
+  def self.remove_namespaces(nodes)
+    nodes.each { |node| node.namespace = nil }
+  end
 end

--- a/lib/vbms/requests.rb
+++ b/lib/vbms/requests.rb
@@ -4,7 +4,8 @@ module VBMS
       "xmlns:soapenv" => "http://schemas.xmlsoap.org/soap/envelope/",
       "xmlns:v4" => "http://vbms.vba.va.gov/external/eDocumentService/v4",
       "xmlns:doc" => "http://vbms.vba.va.gov/cdm/document/v4",
-      "xmlns:efol" => "http://service.efolder.vbms.vba.va.gov/eFolderReadService",
+      "xmlns:upload" => "http://service.efolder.vbms.vba.va.gov/eFolderUploadService",
+      "xmlns:read" => "http://service.efolder.vbms.vba.va.gov/eFolderReadService",
       "xmlns:v5" => "http://vbms.vba.va.gov/cdm/document/v5",
       "xmlns:cdm" => "http://vbms.vba.va.gov/cdm",
       "xmlns:xop" => "http://www.w3.org/2004/08/xop/include"

--- a/lib/vbms/requests/find_document_series_reference.rb
+++ b/lib/vbms/requests/find_document_series_reference.rb
@@ -19,8 +19,8 @@ module VBMS
 
       def soap_doc
         VBMS::Requests.soap do |xml|
-          xml["efol"].findDocumentSeriesReference do
-            xml["efol"].criteria do
+          xml["read"].findDocumentSeriesReference do
+            xml["read"].criteria do
               xml["v5"].veteran(
                 "fileNumber" => @file_number
               )
@@ -37,7 +37,7 @@ module VBMS
 
       def handle_response(doc)
         doc.xpath(
-          "//efol:findDocumentSeriesReferenceResponse/efol:result", VBMS::XML_NAMESPACES
+          "//read:findDocumentSeriesReferenceResponse/read:result", VBMS::XML_NAMESPACES
         ).map do |el|
           construct_response(XMLHelper.convert_to_hash(el.to_xml)[:result])
         end

--- a/lib/vbms/requests/get_document_content.rb
+++ b/lib/vbms/requests/get_document_content.rb
@@ -17,8 +17,8 @@ module VBMS
 
       def soap_doc
         VBMS::Requests.soap do |xml|
-          xml["efol"].getDocumentContent do
-            xml["efol"].documentVersionRefID @document_id
+          xml["read"].getDocumentContent do
+            xml["read"].documentVersionRefID @document_id
           end
         end
       end
@@ -31,7 +31,7 @@ module VBMS
 
       def handle_response(doc)
         el = doc.at_xpath(
-          "//efol:getDocumentContentResponse/efol:result", VBMS::XML_NAMESPACES
+          "//read:getDocumentContentResponse/read:result", VBMS::XML_NAMESPACES
         )
         construct_response(XMLHelper.convert_to_hash(el.to_xml)[:result])
       end

--- a/lib/vbms/requests/initialize_upload.rb
+++ b/lib/vbms/requests/initialize_upload.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+module VBMS
+  module Requests
+    # Call this service with metadata to receive a token used in the second call, uploadDocument
+    class InitializeUpload < BaseRequest
+      def initialize(content_hash:, filename:, file_number:, va_receive_date:, doc_type:, source:)
+        @content_hash = content_hash
+        @filename = filename
+        @file_number = file_number
+        @va_receive_date = va_receive_date
+        @doc_type = doc_type
+        @source = source
+      end
+
+      def name
+        "initializeUpload"
+      end
+
+      def endpoint_url(base_url)
+        "#{base_url}#{VBMS::ENDPOINTS[:efolder_svc_v1][:upload]}"
+      end
+
+      # EST is used because that's what VBMS used in
+      # their sample SoapUI projects.
+      def va_receive_date
+        @va_receive_date.getlocal("-05:00").strftime("%Y-%m-%d-05:00")
+      end
+
+      def soap_doc
+        document = VBMS::Requests.soap do |xml|
+          xml["upload"].initializeUpload do
+            xml.fileName @filename
+            xml.contentHash @content_hash
+            xml.docType @doc_type
+            xml.source @source
+            xml.vaReceiveDate va_receive_date
+            xml.veteranIdentifier(fileNumber: @file_number)
+          end
+        end
+        # in Nokogiri, children inherit their parents' namespace
+        # eFolder Service Version 1.0 in InitializeUpload, does not expect
+        # namespaces inside the 'initializeUpload' element
+        XMLHelper.remove_namespaces(document.at_xpath("//upload:initializeUpload").children)
+        document
+      end
+
+      def signed_elements
+        [["/soapenv:Envelope/soapenv:Body",
+          { soapenv: SoapScum::XMLNamespaces::SOAPENV },
+          "Content"]]
+      end
+
+      def handle_response(doc)
+        el = doc.at_xpath("//upload:initializeUploadResponse", VBMS::XML_NAMESPACES).to_xml
+        { upload_token: XMLHelper.convert_to_hash(el)[:initialize_upload_response][:upload_token] }
+      end
+    end
+  end
+end

--- a/lib/vbms/requests/upload_document.rb
+++ b/lib/vbms/requests/upload_document.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+module VBMS
+  module Requests
+    # This call operates in a two-phase approach. To upload a document,
+    # call initializeUpload with metadata to receive a token used in the second call, uploadDocument
+    # This service replaces UploadDocumentWithAssociation in eDocument Service v4, which is deprecated as of March 2017
+    class UploadDocument < BaseRequest
+      def initialize(upload_token:, filepath:)
+        @upload_token = upload_token
+        @filepath = filepath
+      end
+
+      def name
+        "uploadDocument"
+      end
+
+      def endpoint_url(base_url)
+        "#{base_url}#{VBMS::ENDPOINTS[:efolder_svc_v1][:upload]}"
+      end
+
+      def soap_doc
+        # TODO: convert to using MTOM
+        content = Base64.encode64(File.read(@filepath))
+        document = VBMS::Requests.soap do |xml|
+          xml["upload"].uploadDocument do
+            xml.content content
+            xml.uploadToken @upload_token
+          end
+        end
+        # in Nokogiri, children inherit their parents' namespace
+        # eFolder Service Version 1.0 in InitializeUpload, does not expect
+        # namespaces inside the 'uploadDocument' element
+        XMLHelper.remove_namespaces(document.at_xpath("//upload:uploadDocument").children)
+        document
+      end
+
+      # Double encryption must not be used on operations uploadDocument and updateDocument
+      def signed_elements
+        []
+      end
+
+      # TODO: convert to using MTOM
+      def multipart?
+        false
+      end
+
+      def multipart_file
+        @filepath
+      end
+
+      def handle_response(doc)
+        el = doc.xpath("//upload:uploadDocumentResponse", VBMS::XML_NAMESPACES).to_xml
+        XMLHelper.convert_to_hash(el)
+      end
+    end
+  end
+end

--- a/spec/fixtures/requests/initialize_upload.xml
+++ b/spec/fixtures/requests/initialize_upload.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+  <env:Header>
+  </env:Header>
+  <env:Body xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="id-208">
+    <initializeUploadResponse xmlns="http://service.efolder.vbms.vba.va.gov/eFolderUploadService" xmlns:com="http://vbms.vba.va.gov/cdm/common/v4" xmlns:doc="http://vbms.vba.va.gov/cdm/document/v5" xmlns:efc="http://service.efolder.vbms.vba.va.gov/common" xmlns:efu="http://service.efolder.vbms.vba.va.gov/eFolderUploadService" xmlns:part="http://vbms.vba.va.gov/cdm/participant/v4"><uploadToken xmlns="">{1587FC2D-63FA-40EA-8E59-D99FF790395B}</uploadToken></initializeUploadResponse>
+  </env:Body>
+</env:Envelope>

--- a/spec/fixtures/requests/upload_document.xml
+++ b/spec/fixtures/requests/upload_document.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+  <env:Header>
+  </env:Header>
+  <env:Body xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="id-91">
+    <uploadDocumentResponse xmlns="http://service.efolder.vbms.vba.va.gov/eFolderUploadService" xmlns:com="http://vbms.vba.va.gov/cdm/common/v4" xmlns:efc="http://service.efolder.vbms.vba.va.gov/common" xmlns:efu="http://service.efolder.vbms.vba.va.gov/eFolderUploadService" xmlns:part="http://vbms.vba.va.gov/cdm/participant/v4" xmlns:doc="http://vbms.vba.va.gov/cdm/document/v5" newDocumentVersionRefId="{2F1A4BCB-F80F-45BF-82A6-CC9E5DAF3B81}" documentSeriesRefId="{60494099-3440-4624-9BAC-E791589914A0}" mimeType="application/pdf">
+      <veteranReference xmlns="">
+        <doc:id fileNumber="784449089"/>
+      </veteranReference>
+      <typeCategory xmlns="" categoryId="44" categoryDescriptionText="Medical Records" typeId="356" typeDescriptionText="C&amp;P Exam" typeLabelText="L214"/>
+      <vaReceiveDate xmlns="">2017-03-10-05:00</vaReceiveDate>
+      <vbmsUploadDate xmlns="">2017-03-10-05:00</vbmsUploadDate>
+    </uploadDocumentResponse>
+  </env:Body>
+</env:Envelope>

--- a/spec/fixtures/responses/initialize_upload.xml
+++ b/spec/fixtures/responses/initialize_upload.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+  <env:Header>
+    <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+      <xenc:EncryptedKey xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" Id="EK-A0B3C6A634B2F446FA1489068059885210">
+        <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+        <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+          <wsse:SecurityTokenReference>
+            <ds:X509Data>
+              <ds:X509IssuerSerial>
+                <ds:X509IssuerName>CN=Scanning CA,OU=Scanning CA,O=Scanning CA,L=Culpeper,ST=Virginia,C=US</ds:X509IssuerName>
+                <ds:X509SerialNumber>49</ds:X509SerialNumber>
+              </ds:X509IssuerSerial>
+            </ds:X509Data>
+          </wsse:SecurityTokenReference>
+        </ds:KeyInfo>
+        <xenc:CipherData>
+          <xenc:CipherValue>ETIHUsPt7nIh+1/95yob/Ow4rvmP3ViB4BfxjGAQw+UqIH78KRJV0MIBD9q6OgQzAIbvpzIHyS96FttyG1TTv6oWzSLFupVfjJ8XIH6VsAd5FEBQE2MHc9Ao3MVnD5ASvdNCsRM3+VeJbYjxkmdjJybee1ERZCuvnnj6aoZUzgAiyouNMelCCvooCTmC8GPARUbiRz9zYikrM3XdP+WS8fLe8GVwS0MmjJp2gBL1ecPazfcesiB0c6QBEfNVvx9hj2NBYawYzz2uwEVSTzSqr3HV+i20xKDHJtipru6A0UZ4kkpIUYpUjs+sJnjzi/W5MJ8ET8RHjeYQOYpgPNpW5w==</xenc:CipherValue>
+        </xenc:CipherData>
+        <xenc:ReferenceList>
+          <xenc:DataReference URI="#ED-210"/>
+        </xenc:ReferenceList>
+      </xenc:EncryptedKey>
+      <wsu:Timestamp wsu:Id="TS-207">
+        <wsu:Created>2017-03-09T14:00:59.877Z</wsu:Created>
+        <wsu:Expires>2017-03-09T14:05:59.877Z</wsu:Expires>
+      </wsu:Timestamp>
+      <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="SIG-209">
+        <ds:SignedInfo>
+          <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="env"/>
+          </ds:CanonicalizationMethod>
+          <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+          <ds:Reference URI="#TS-207">
+            <ds:Transforms>
+              <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+                <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="wsse env"/>
+              </ds:Transform>
+            </ds:Transforms>
+            <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+            <ds:DigestValue>mKeauAQiSBL7wEf0521ubjBMfYU=</ds:DigestValue>
+          </ds:Reference>
+          <ds:Reference URI="#id-208">
+            <ds:Transforms>
+              <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+                <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList=""/>
+              </ds:Transform>
+            </ds:Transforms>
+            <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+            <ds:DigestValue>D+qMC105Lr3IC9Ll7gjugFKfcxk=</ds:DigestValue>
+          </ds:Reference>
+        </ds:SignedInfo>
+        <ds:SignatureValue>OMg8PBo/8ykE5txMPV9shkHDvc4IvPTySeEeTemgMgPuOPKw1Wxx7gOx7CGD22bbYNpcnaozEbkW
+Hnv9cSNTQhEtRQUYUAb5eby1Ls5gUova9xHGnM4FG+cnZ5ZIwQRyvCFaXJPZFiGs3HXJ6HI/VjyK
+5ZZTw0yzrCztkRRsGv3zSHElaiz8fWI98AUdNEO4novgcypeBk8XvoubjvRlaTp8/pfn4nW3KK/o
+6W3tgzOOide5eefq5SlzXzGQbKDzXDF9SNJjgBattcVR7hvsRtsUobnq+ZhPexVIJodxEbYK4s0U
+qJvKpRLr4RuT5zW0jqCgO+dWwvpzfqZBvfTx4A==</ds:SignatureValue>
+        <ds:KeyInfo Id="KI-A0B3C6A634B2F446FA1489068059877208">
+          <wsse:SecurityTokenReference wsu:Id="STR-A0B3C6A634B2F446FA1489068059877209">
+            <ds:X509Data>
+              <ds:X509IssuerSerial>
+                <ds:X509IssuerName>CN=AIDE CA2,OU=CA2,O=AIDE,L=Culpeper,ST=Virginia,C=US</ds:X509IssuerName>
+                <ds:X509SerialNumber>4</ds:X509SerialNumber>
+              </ds:X509IssuerSerial>
+            </ds:X509Data>
+          </wsse:SecurityTokenReference>
+        </ds:KeyInfo>
+      </ds:Signature>
+    </wsse:Security>
+  </env:Header>
+  <env:Body xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="id-208">
+    <initializeUploadResponse xmlns="http://service.efolder.vbms.vba.va.gov/eFolderUploadService" xmlns:com="http://vbms.vba.va.gov/cdm/common/v4" xmlns:doc="http://vbms.vba.va.gov/cdm/document/v5" xmlns:efc="http://service.efolder.vbms.vba.va.gov/common" xmlns:efu="http://service.efolder.vbms.vba.va.gov/eFolderUploadService" xmlns:part="http://vbms.vba.va.gov/cdm/participant/v4"><uploadToken xmlns="">{1587FC2D-63FA-40EA-8E59-D99FF790395B}</uploadToken></initializeUploadResponse>
+  </env:Body>
+</env:Envelope>

--- a/spec/fixtures/responses/upload_document.xml
+++ b/spec/fixtures/responses/upload_document.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+  <env:Header>
+    <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+      <wsu:Timestamp wsu:Id="TS-90">
+        <wsu:Created>2017-03-10T16:36:40.053Z</wsu:Created>
+        <wsu:Expires>2017-03-10T16:41:40.053Z</wsu:Expires>
+      </wsu:Timestamp>
+      <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="SIG-92">
+        <ds:SignedInfo>
+          <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="env"/>
+          </ds:CanonicalizationMethod>
+          <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+          <ds:Reference URI="#TS-90">
+            <ds:Transforms>
+              <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+                <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="wsse env"/>
+              </ds:Transform>
+            </ds:Transforms>
+            <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+            <ds:DigestValue>IFu9SoNbhXai/K4XyPMdtwVz3wk=</ds:DigestValue>
+          </ds:Reference>
+          <ds:Reference URI="#id-91">
+            <ds:Transforms>
+              <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+                <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList=""/>
+              </ds:Transform>
+            </ds:Transforms>
+            <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+            <ds:DigestValue>XSJ5sbAPDq5bJtKC829hzS2cVzA=</ds:DigestValue>
+          </ds:Reference>
+        </ds:SignedInfo>
+        <ds:SignatureValue>uMAiCizESYU18PArGpYeovweNhXiMNjOAzn2YK4HSroMD4mwBjJI5EgoGoRBblzT8TJoxdFgPmq0
+fTaJnVP/9Vx2MUV+7rOB957I6atSbAVOyDNYuFoAUDh1A7Yd08zrSZp9y7UIehwkv0kvQCA+Dinm
+YXcuZBdEogOES7G7dB+reu6YDWFOjup6iQoZPNC4hO28dXI4IyIBAp6HzGK+Zhvrl1c5fwlnIhTV
+AL6ot1ldk2UDeEwEI0Zi+PoCJVH5gNMSE6TjrD96/JAMmQVInXkuczJdcj04H6ISfDWHES9B/h5K
+LFm9eUMFNIPZc3OXTnt+j+eFKcOv8ragsD+aKw==</ds:SignatureValue>
+        <ds:KeyInfo Id="KI-A21247356141E189CF148916380005491">
+          <wsse:SecurityTokenReference wsu:Id="STR-A21247356141E189CF148916380005492">
+            <ds:X509Data>
+              <ds:X509IssuerSerial>
+                <ds:X509IssuerName>CN=AIDE CA2,OU=CA2,O=AIDE,L=Culpeper,ST=Virginia,C=US</ds:X509IssuerName>
+                <ds:X509SerialNumber>4</ds:X509SerialNumber>
+              </ds:X509IssuerSerial>
+            </ds:X509Data>
+          </wsse:SecurityTokenReference>
+        </ds:KeyInfo>
+      </ds:Signature>
+    </wsse:Security>
+  </env:Header>
+  <env:Body xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="id-91">
+    <uploadDocumentResponse xmlns="http://service.efolder.vbms.vba.va.gov/eFolderUploadService" xmlns:com="http://vbms.vba.va.gov/cdm/common/v4" xmlns:efc="http://service.efolder.vbms.vba.va.gov/common" xmlns:efu="http://service.efolder.vbms.vba.va.gov/eFolderUploadService" xmlns:part="http://vbms.vba.va.gov/cdm/participant/v4" xmlns:doc="http://vbms.vba.va.gov/cdm/document/v5" newDocumentVersionRefId="{2F1A4BCB-F80F-45BF-82A6-CC9E5DAF3B81}" documentSeriesRefId="{60494099-3440-4624-9BAC-E791589914A0}" mimeType="application/pdf">
+      <veteranReference xmlns="">
+        <doc:id fileNumber="784449089"/>
+      </veteranReference>
+      <typeCategory xmlns="" categoryId="44" categoryDescriptionText="Medical Records" typeId="356" typeDescriptionText="C&amp;P Exam" typeLabelText="L214"/>
+      <vaReceiveDate xmlns="">2017-03-10-05:00</vaReceiveDate>
+      <vbmsUploadDate xmlns="">2017-03-10-05:00</vbmsUploadDate>
+    </uploadDocumentResponse>
+  </env:Body>
+</env:Envelope>

--- a/spec/requests/initialize_upload_spec.rb
+++ b/spec/requests/initialize_upload_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+describe VBMS::Requests::InitializeUpload do
+  describe "soap_doc" do
+    subject do 
+      VBMS::Requests::InitializeUpload.new(content_hash: "1a1389d7934dc6444ce6471beb9fcf16ff57221f",
+                                           filename: "test1.pdf",
+                                           file_number: "784449089",
+                                           va_receive_date: Time.now,
+                                           doc_type: "356",
+                                           source: "Connect VBMS test") 
+    end
+
+    it "generates valid SOAP" do
+      xml = subject.soap_doc.to_xml
+      xsd = Nokogiri::XML::Schema(fixture("soap.xsd"))
+      expect(xsd.errors).to eq []
+      errors = xsd.validate(parse_strict(xml))
+      expect(errors).to eq []
+    end
+  end
+
+  describe "parsing the XML" do
+    before(:all) do
+      request = VBMS::Requests::InitializeUpload.new(content_hash: "1a1389d7934dc6444ce6471beb9fcf16ff57221f",
+                                                     filename: "test1.pdf",
+                                                     file_number: "784449089",
+                                                     va_receive_date: Time.now,
+                                                     doc_type: "356",
+                                                     source: "Connect VBMS test")
+      xml = fixture("responses/initialize_upload.xml")
+      doc = parse_strict(xml)
+      @response = request.handle_response(doc)
+    end
+
+    subject { @response }
+
+    it "returns upload token" do
+      expect(subject[:upload_token]).to eq "{1587FC2D-63FA-40EA-8E59-D99FF790395B}"
+    end
+  end
+end

--- a/spec/requests/upload_document_spec.rb
+++ b/spec/requests/upload_document_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+describe VBMS::Requests::UploadDocument do
+  before(:all) do
+    @file = Tempfile.new("foo")
+    @file.write("hello world")
+  end
+
+  describe "soap_doc" do
+    subject do 
+      VBMS::Requests::UploadDocument.new(upload_token: "{1587FC2D-63FA-40EA-8E59-D99FF790395B}",
+                                         filepath: @file.path) 
+    end
+
+    it "generates valid SOAP" do
+      xml = subject.soap_doc.to_xml
+      xsd = Nokogiri::XML::Schema(fixture("soap.xsd"))
+      expect(xsd.errors).to eq []
+      errors = xsd.validate(parse_strict(xml))
+      expect(errors).to eq []
+    end
+  end
+
+  describe "parsing the XML" do
+    before(:all) do
+      request = VBMS::Requests::UploadDocument.new(upload_token: "{1587FC2D-63FA-40EA-8E59-D99FF790395B}",
+                                                   filepath: @file.path)
+      xml = fixture("responses/upload_document.xml")
+      doc = parse_strict(xml)
+      @response = request.handle_response(doc)
+    end
+
+    subject { @response }
+
+    it "returns upload token" do
+      expect(subject[:upload_document_response][:@new_document_version_ref_id]).to eq "{2F1A4BCB-F80F-45BF-82A6-CC9E5DAF3B81}"
+    end
+  end
+
+  after(:all) do
+    @file.close
+    @file.unlink
+  end
+end


### PR DESCRIPTION
InitializeUpload and UploadDocument API to replace UploadDocumentWithAssociation in eDocument Service v4. 

Issues that need to be resolved with VBMS team (tickets with VBMS team to follow): 
1. examName and newMail parameters are no longer supported when uploading documents (need to confirm this with the team)
2. If I use MTOM upload operations and send a document as a MIME attachment using UTF-8 encoding, I receive an error message: `invalid hash of the document`. If I don’t use MTOM and send a document inside the XML body encoded in base64, I am able to upload a document successfully.  
