### PR TITLE
Return OpenStruct data structure.

### DIFF
--- a/lib/vbms/common.rb
+++ b/lib/vbms/common.rb
@@ -54,7 +54,7 @@ module VBMS
     attr_reader :code, :body
 
     def initialize(code, body)
-      super("status_code=#{code}, body=#{body[0..250]}...")
+      super("status_code=#{code}, body=#{body}")
       @code = code
       @body = body
     end

--- a/lib/vbms/requests/find_document_series_reference.rb
+++ b/lib/vbms/requests/find_document_series_reference.rb
@@ -71,7 +71,7 @@ module VBMS
       end
 
       def source(version)
-         version[:source].present? ? version[:source][:@source_name] : nil
+        version[:source].present? ? version[:source][:@source_name] : nil
       end
     end
   end

--- a/lib/vbms/requests/find_document_series_reference.rb
+++ b/lib/vbms/requests/find_document_series_reference.rb
@@ -45,21 +45,26 @@ module VBMS
 
       private
 
+      # rubocop:disable Metrics/CyclomaticComplexity
       def construct_response(result)
         version = XMLHelper.most_recent_version(result[:versions])
         alt_doc_types = XMLHelper.find_hash_by_key(version[:metadata], "altDocType")
         restricted = XMLHelper.find_hash_by_key(version[:metadata], "restricted")
-        {
+        type_category = version[:type_category]
+        source = version[:source]
+        OpenStruct.new(
           document_id: version[:@document_version_ref_id],
-          type_description: version[:type_category][:@type_description_text],
-          type_id: version[:type_category][:@type_id],
-          va_receive_date: version[:va_receive_date],
-          source: version[:source][:@source_name],
+          type_description: type_category.present? ? type_category[:@type_description_text] : nil,
+          type_id: type_category.present? ? type_category[:@type_id] : nil,
+          doc_type: type_category.present? ? type_category[:@type_id] : nil,
+          received_at: version[:va_receive_date],
+          source: source.present? ? source[:@source_name] : nil,
           mime_type: version[:@mime_type],
           alt_doc_types: alt_doc_types.present? ? JSON.parse(alt_doc_types[:value]) : nil,
           restricted: restricted.present? ? restricted[:value] : nil
-        }
+        )
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
     end
   end
 end

--- a/lib/vbms/requests/find_document_series_reference.rb
+++ b/lib/vbms/requests/find_document_series_reference.rb
@@ -45,26 +45,34 @@ module VBMS
 
       private
 
-      # rubocop:disable Metrics/CyclomaticComplexity
       def construct_response(result)
         version = XMLHelper.most_recent_version(result[:versions])
         alt_doc_types = XMLHelper.find_hash_by_key(version[:metadata], "altDocType")
         restricted = XMLHelper.find_hash_by_key(version[:metadata], "restricted")
-        type_category = version[:type_category]
-        source = version[:source]
         OpenStruct.new(
           document_id: version[:@document_version_ref_id],
-          type_description: type_category.present? ? type_category[:@type_description_text] : nil,
-          type_id: type_category.present? ? type_category[:@type_id] : nil,
-          doc_type: type_category.present? ? type_category[:@type_id] : nil,
+          type_description: type_description(version),
+          type_id: type_id(version),
+          doc_type: type_id(version),
           received_at: version[:va_receive_date],
-          source: source.present? ? source[:@source_name] : nil,
+          source: source(version),
           mime_type: version[:@mime_type],
           alt_doc_types: alt_doc_types.present? ? JSON.parse(alt_doc_types[:value]) : nil,
           restricted: restricted.present? ? restricted[:value] : nil
         )
       end
-      # rubocop:enable Metrics/CyclomaticComplexity
+
+      def type_description(version)
+        version[:type_category].present? ? version[:type_category][:@type_description_text] : nil
+      end
+
+      def type_id(version)
+        version[:type_category].present? ? version[:type_category][:@type_id] : nil
+      end
+
+      def source(version)
+         version[:source].present? ? version[:source][:@source_name] : nil
+      end
     end
   end
 end

--- a/lib/vbms/requests/get_document_content.rb
+++ b/lib/vbms/requests/get_document_content.rb
@@ -39,10 +39,10 @@ module VBMS
       private
 
       def construct_response(result)
-        {
+        OpenStruct.new(
           document_id: result[:@document_version_reference_id],
           content: Base64.decode64(result[:bytes])
-        }
+        )
       end
     end
   end

--- a/lib/vbms/requests/initialize_upload.rb
+++ b/lib/vbms/requests/initialize_upload.rb
@@ -52,7 +52,7 @@ module VBMS
 
       def handle_response(doc)
         el = doc.at_xpath("//upload:initializeUploadResponse", VBMS::XML_NAMESPACES).to_xml
-        { upload_token: XMLHelper.convert_to_hash(el)[:initialize_upload_response][:upload_token] }
+        OpenStruct.new(upload_token: XMLHelper.convert_to_hash(el)[:initialize_upload_response][:upload_token])
       end
     end
   end

--- a/lib/vbms/requests/upload_document.rb
+++ b/lib/vbms/requests/upload_document.rb
@@ -50,7 +50,7 @@ module VBMS
 
       def handle_response(doc)
         el = doc.xpath("//upload:uploadDocumentResponse", VBMS::XML_NAMESPACES).to_xml
-        XMLHelper.convert_to_hash(el)
+        OpenStruct.new(XMLHelper.convert_to_hash(el))
       end
     end
   end

--- a/lib/vbms/requests/upload_document.rb
+++ b/lib/vbms/requests/upload_document.rb
@@ -28,7 +28,7 @@ module VBMS
           end
         end
         # in Nokogiri, children inherit their parents' namespace
-        # eFolder Service Version 1.0 in InitializeUpload, does not expect
+        # eFolder Service Version 1.0 in UploadDocument, does not expect
         # namespaces inside the 'uploadDocument' element
         XMLHelper.remove_namespaces(document.at_xpath("//upload:uploadDocument").children)
         document

--- a/spec/requests/find_document_series_reference_spec.rb
+++ b/spec/requests/find_document_series_reference_spec.rb
@@ -35,7 +35,7 @@ describe VBMS::Requests::FindDocumentSeriesReference do
       expect(doc1[:type_id]).to eq "356"
       expect(doc1[:source]).to eq "VHA_CUI"
       expect(doc1[:restricted]).to eq false
-      expect(doc1[:va_receive_date]).to eq Date.parse("2014-11-16-04:00")
+      expect(doc1[:received_at]).to eq Date.parse("2014-11-16-04:00")
 
       # document with alt doc types and one version
       doc2 = subject.third
@@ -45,7 +45,7 @@ describe VBMS::Requests::FindDocumentSeriesReference do
       expect(doc2[:type_id]).to eq "857"
       expect(doc2[:source]).to eq "VACOLS"
       expect(doc2[:restricted]).to eq true
-      expect(doc2[:va_receive_date]).to eq Date.parse("2014-04-30-04:00")
+      expect(doc2[:received_at]).to eq Date.parse("2014-04-30-04:00")
     end
   end
 end


### PR DESCRIPTION
1. Return OpenStruct data structures for GetDocumentContent and FindDocumentSeriesReference to convert hash keys to object properties (this will lead to a minimal re-factoring on eFolder Express that expects an array of Document objects when calling ListDocuments service)
2. Add more error checking for `source` and `type_category` as I found a few cases where source came back as nil. 