### PR TITLE
Send subject and new_mail params when uploading a doc

### DIFF
--- a/lib/vbms/requests/find_document_series_reference.rb
+++ b/lib/vbms/requests/find_document_series_reference.rb
@@ -54,6 +54,7 @@ module VBMS
           type_description: type_description(version),
           type_id: type_id(version),
           doc_type: type_id(version),
+          subject: version[:@subject],
           received_at: version[:va_receive_date],
           source: source(version),
           mime_type: version[:@mime_type],

--- a/lib/vbms/requests/initialize_upload.rb
+++ b/lib/vbms/requests/initialize_upload.rb
@@ -3,13 +3,15 @@ module VBMS
   module Requests
     # Call this service with metadata to receive a token used in the second call, uploadDocument
     class InitializeUpload < BaseRequest
-      def initialize(content_hash:, filename:, file_number:, va_receive_date:, doc_type:, source:)
+      def initialize(content_hash:, filename:, file_number:, va_receive_date:, doc_type:, source:, subject:, new_mail:)
         @content_hash = content_hash
         @filename = filename
         @file_number = file_number
         @va_receive_date = va_receive_date
         @doc_type = doc_type
         @source = source
+        @subject = subject
+        @new_mail = new_mail
       end
 
       def name
@@ -35,6 +37,12 @@ module VBMS
             xml.source @source
             xml.vaReceiveDate va_receive_date
             xml.veteranIdentifier(fileNumber: @file_number)
+            xml.versionMetadata(key: "subject") do
+              xml["v5"].value @subject
+            end
+            xml.versionMetadata(key: "newMail") do
+              xml["v5"].value @new_mail
+            end
           end
         end
         # in Nokogiri, children inherit their parents' namespace

--- a/spec/requests/find_document_series_reference_spec.rb
+++ b/spec/requests/find_document_series_reference_spec.rb
@@ -34,6 +34,7 @@ describe VBMS::Requests::FindDocumentSeriesReference do
       expect(doc1[:type_description]).to eq "C&#38;P Exam"
       expect(doc1[:type_id]).to eq "356"
       expect(doc1[:source]).to eq "VHA_CUI"
+      expect(doc1[:subject]).to eq "Knee"
       expect(doc1[:restricted]).to eq false
       expect(doc1[:received_at]).to eq Date.parse("2014-11-16-04:00")
 

--- a/spec/requests/initialize_upload_spec.rb
+++ b/spec/requests/initialize_upload_spec.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 describe VBMS::Requests::InitializeUpload do
   describe "soap_doc" do
-    subject do 
+    subject do
       VBMS::Requests::InitializeUpload.new(content_hash: "1a1389d7934dc6444ce6471beb9fcf16ff57221f",
                                            filename: "test1.pdf",
                                            file_number: "784449089",
                                            va_receive_date: Time.now,
                                            doc_type: "356",
-                                           source: "Connect VBMS test") 
+                                           source: "Connect VBMS test",
+                                           subject: "head",
+                                           new_mail: true)
     end
 
     it "generates valid SOAP" do
@@ -26,7 +28,9 @@ describe VBMS::Requests::InitializeUpload do
                                                      file_number: "784449089",
                                                      va_receive_date: Time.now,
                                                      doc_type: "356",
-                                                     source: "Connect VBMS test")
+                                                     source: "Connect VBMS test",
+                                                     subject: "head",
+                                                     new_mail: true)
       xml = fixture("responses/initialize_upload.xml")
       doc = parse_strict(xml)
       @response = request.handle_response(doc)

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -47,7 +47,9 @@ describe VBMS::Requests do
                                                      file_number: "784449089",
                                                      va_receive_date: Time.now,
                                                      doc_type: "356",
-                                                     source: "VHA_CUI")
+                                                     source: "VHA_CUI",
+                                                     subject: "knee",
+                                                     new_mail: true)
 
       webmock_soap_response("#{@client.base_url}#{VBMS::ENDPOINTS[:efolder_svc_v1][:upload]}",
                             "initialize_upload",
@@ -92,7 +94,9 @@ describe VBMS::Requests do
                                                      file_number: "784449089",
                                                      va_receive_date: Time.now,
                                                      doc_type: "356",
-                                                     source: "Connect VBMS test")
+                                                     source: "Connect VBMS test",
+                                                     subject: "knee",
+                                                     new_mail: true)
 
       webmock_soap_response("#{@client.base_url}#{VBMS::ENDPOINTS[:efolder_svc_v1][:upload]}",
                             "initialize_upload",


### PR DESCRIPTION
Send `new mail` and `subject` when uploading a document. 

YAY, there is a way to do it!