### PR TITLE
Log request object on failure

### DIFF
--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -83,7 +83,7 @@ module VBMS
       )
 
       if response.code != 200
-        fail VBMS::HTTPError.new(response.code, response.body)
+        fail VBMS::HTTPError.new(response.code, response.body, request)
       end
 
       process_response(request, response)

--- a/lib/vbms/common.rb
+++ b/lib/vbms/common.rb
@@ -53,10 +53,11 @@ module VBMS
   class HTTPError < ClientError
     attr_reader :code, :body
 
-    def initialize(code, body)
-      super("status_code=#{code}, body=#{body}")
+    def initialize(code, body, request)
+      super("status_code=#{code}, body=#{body}, request=#{request.inspect}")
       @code = code
       @body = body
+      @request = request
     end
   end
 


### PR DESCRIPTION
Log Request object on failures to make debugging easier. The message would look something like that:

```
VBMS::HTTPError:
status_code=500, body=--uuid:778dbb74-4bd5-44c7-845d-64cfc86bbc71
Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"
Content-Transfer-Encoding: binary
Content-ID: <root.message@cxf.apache.org>

 <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Header/><env:Body><env:Fault><faultcode>env:Server</faultcode><faultstring>Business Errors GUID: 114233b9-f6d6-48e2-b4a5-37e5521364a7</faultstring><detail><efc:EFolderFault xmlns:part="http://vbms.vba.va.gov/cdm/participant/v4" xmlns:efu="http://service.efolder.vbms.vba.va.gov/eFolderUploadService" xmlns:efc="http://service.efolder.vbms.vba.va.gov/common" xmlns:doc="http://vbms.vba.va.gov/cdm/document/v5" xmlns:com="http://vbms.vba.va.gov/cdm/common/v4"><efc:code>EFSERR1013</efc:code><efc:message>Document already uploaded.</efc:message><efc:type>Business</efc:type><efc:uuid>114233b9-f6d6-48e2-b4a5-37e5521364a7</efc:uuid></efc:EFolderFault></detail></env:Fault></env:Body></env:Envelope>
--uuid:778dbb74-4bd5-44c7-845d-64cfc86bbc71--, 

request=#<VBMS::Requests::UploadDocument:0x007ffc2743bbf8 @upload_token="{91836159-8D6E-471C-85E3-7EE9DAD36938}", @filepath="/var/folders/bv/_yl8rrjj64l_x8976nspm5t1h8gk4q/T/tmp20170329-14799-1nx9lxi.txt">
```
