### PR TITLE
There are cases in UAT when versions are coming back as nil

### DIFF
--- a/lib/vbms/common.rb
+++ b/lib/vbms/common.rb
@@ -51,9 +51,9 @@ module VBMS
   end
 
   class HTTPError < ClientError
-    attr_reader :code, :body
+    attr_reader :code, :body, :request
 
-    def initialize(code, body, request)
+    def initialize(code, body, request = nil)
       super("status_code=#{code}, body=#{body}, request=#{request.inspect}")
       @code = code
       @body = body

--- a/lib/vbms/helpers/xml_helper.rb
+++ b/lib/vbms/helpers/xml_helper.rb
@@ -24,10 +24,14 @@ module XMLHelper
   # when Nori (XML parser) parses the versions in XML document, if it finds multiple versions
   # it creates an array of hashes; if it finds a single version, it creates a hash
   def self.most_recent_version(versions)
-    versions.is_a?(Array) ? versions.sort_by { |v| v[:version][:@major].to_i }.last : versions
+    versions.is_a?(Array) ? sort_versions(versions) : versions
   end
 
   def self.remove_namespaces(nodes)
     nodes.each { |node| node.namespace = nil }
+  end
+
+  def self.sort_versions(versions)
+    versions.sort_by { |v| v[:version].try(:[], :@major).to_i }.last
   end
 end

--- a/spec/helpers/xml_helper_spec.rb
+++ b/spec/helpers/xml_helper_spec.rb
@@ -27,6 +27,7 @@ describe XMLHelper do
   context ".most_recent_version" do
     let(:h1) { { version: { :@major => "45" } } }
     let(:h2) { { version: { :@major => "88" } } }
+    let(:h3) { { version: nil } }
 
     subject { XMLHelper.most_recent_version(versions) }
 
@@ -38,6 +39,11 @@ describe XMLHelper do
     context "when versions is a hash" do
       let(:versions) { h1 }
       it { is_expected.to eq(version: { :@major => "45" }) }
+    end
+
+    context "when version is nil" do
+      let(:versions) { [h1, h3, h2] }
+      it { is_expected.to eq(version: { :@major => "88" }) }
     end
   end
 end


### PR DESCRIPTION
1. I ran into a few cases in UAT where versions came back as nil. Adding protective code around this edge case. 
2. When initializing a VBMS error, make `request` param optional.  