### PR TITLE
If XML has no body, return error msg

### DIFF
--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -191,12 +191,6 @@ module VBMS
       )
     end
 
-    def parse_body(xml)
-      doc = parse_xml_strictly(xml)
-      doc.at_xpath("/soapenv:Envelope/soapenv:Body",
-                   soapenv: "http://schemas.xmlsoap.org/soap/envelope/")
-    end
-
     def process_response(request, response)
       parser = MultipartParser.new(response)
       doc = parse_xml_strictly(parser.xml_content)
@@ -220,6 +214,11 @@ module VBMS
 
       fail SOAPError.new("SOAP Fault returned", response.body) if
         soap.at_xpath("//soapenv:Fault", VBMS::XML_NAMESPACES)
+
+      soap = doc.at_xpath("/soapenv:Envelope/soapenv:Body",
+                   soapenv: "http://schemas.xmlsoap.org/soap/envelope/")
+      fail SOAPError.new("No SOAP body found in response", response.body) if
+        soap.nil?
     end
   end
 end

--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -216,7 +216,7 @@ module VBMS
         soap.at_xpath("//soapenv:Fault", VBMS::XML_NAMESPACES)
 
       soap = doc.at_xpath("/soapenv:Envelope/soapenv:Body",
-                   soapenv: "http://schemas.xmlsoap.org/soap/envelope/")
+                          soapenv: "http://schemas.xmlsoap.org/soap/envelope/")
       fail SOAPError.new("No SOAP body found in response", response.body) if
         soap.nil?
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -158,6 +158,24 @@ describe VBMS::Client do
       end
     end
 
+    context "when it is given a document that does not have body" do
+      let(:response_body) do
+        <<-EOF
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+          <soap:Header/>
+        </soap:Envelope>
+        EOF
+      end
+
+      it "should raise a SOAPError" do
+        expect { subject }.to raise_error do |error|
+          expect(error).to be_a(VBMS::SOAPError)
+          expect(error.message).to eq("No SOAP body found in response")
+          expect(error.body).to eq(response_body)
+        end
+      end
+    end
+
     context "when the server sends an HTML response error page" do
       let(:response_body) do
         <<-EOF


### PR DESCRIPTION
I am hoping this will fix Sentry error: https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/578/events/12785/