### PR TITLE
Add contention endpoints

### DIFF
--- a/lib/vbms.rb
+++ b/lib/vbms.rb
@@ -22,6 +22,7 @@ require "vbms/responses/document"
 require "vbms/responses/document_type"
 require "vbms/responses/document_with_content"
 require "vbms/responses/claim"
+require "vbms/responses/contention"
 
 require "vbms/requests/base_request"
 # eDocument Service v4
@@ -30,6 +31,8 @@ require "vbms/requests/list_documents"
 require "vbms/requests/fetch_document_by_id"
 require "vbms/requests/get_document_types"
 require "vbms/requests/establish_claim"
+require "vbms/requests/create_contentions"
+require "vbms/requests/list_contentions"
 
 # eFolder Service 1.0
 require "vbms/requests/find_document_series_reference"

--- a/lib/vbms/common.rb
+++ b/lib/vbms/common.rb
@@ -25,6 +25,7 @@ module VBMS
   XML_NAMESPACES = {
     v4: "http://vbms.vba.va.gov/external/eDocumentService/v4",
     ns2: "http://vbms.vba.va.gov/cdm/document/v4",
+    ns0: "http://vbms.vba.va.gov/cdm/claim/v4",
     upload: "http://service.efolder.vbms.vba.va.gov/eFolderUploadService",
     read: "http://service.efolder.vbms.vba.va.gov/eFolderReadService",
     v5: "http://vbms.vba.va.gov/cdm/document/v5",

--- a/lib/vbms/requests/create_contentions.rb
+++ b/lib/vbms/requests/create_contentions.rb
@@ -69,7 +69,7 @@ module VBMS
           "//claimV4:createContentionsResponse/claimV4:createdContentions",
           VBMS::XML_NAMESPACES
         ).map do |xml|
-          VBMS::Responses::Contention.create_from_xml(xml)
+          VBMS::Responses::Contention.create_from_xml(xml, key: :created_contentions)
         end
       end
     end

--- a/lib/vbms/requests/create_contentions.rb
+++ b/lib/vbms/requests/create_contentions.rb
@@ -1,0 +1,77 @@
+module VBMS
+  module Requests
+    class CreateContentions < BaseRequest
+      NAMESPACES = {
+        "xmlns:cla" => "http://vbms.vba.va.gov/external/ClaimService/v4",
+        "xmlns:cdm" => "http://vbms.vba.va.gov/cdm/claim/v4",
+        "xmlns:participant" => "http://vbms.vba.va.gov/cdm/participant/v4"
+      }.freeze
+
+      # Contentions should be an array of strings representing the contentions
+      def initialize(veteran_file_number:, claim_id:, contentions:)
+        @veteran_file_number = veteran_file_number
+        @claim_id = claim_id
+        @contentions = contentions
+      end
+
+      def name
+        "createContentions"
+      end
+
+      def endpoint_url(base_url)
+        "#{base_url}#{VBMS::ENDPOINTS[:claims]}"
+      end
+
+      def inject_header_content(header_xml)
+        Nokogiri::XML::Builder.with(header_xml) do |xml|
+          xml["vbmsext"].userId("dslogon.1011239249", "xmlns:vbmsext" => "http://vbms.vba.va.gov/external")
+        end
+      end
+
+      def soap_doc
+        VBMS::Requests.soap(more_namespaces: NAMESPACES) do |xml|
+          xml["cla"].createContentions do
+            @contentions.each do |contention_text|
+              xml["cla"].contentionsToCreate(
+                # 0 means the id will be auto generated
+                id: "0",
+
+                # 0 means there is no parent contention
+                secondaryToContentionID: "0",
+
+                fileNumber: @veteran_file_number,
+                claimId: @claim_id,
+                title: contention_text,
+
+                actionableItem: "true",
+                medical: "false",
+                typeCode: "NEW",
+                workingContention: "YES",
+
+                awaitingResponse: "unused. but requrired.",
+                partcipantContention: "unused, but required."
+              ) do
+                xml["cdm"].submitDate Date.today.iso8601
+              end
+            end
+          end
+        end
+      end
+
+      def signed_elements
+        [["/soapenv:Envelope/soapenv:Body",
+          { soapenv: SoapScum::XMLNamespaces::SOAPENV },
+          "Content"]]
+      end
+
+      def handle_response(doc)
+        doc.xpath(
+          "//claimV4:createContentionsResponse/claimV4:createdContentions",
+          VBMS::XML_NAMESPACES
+        ).map do |xml|
+          VBMS::Responses::Contention.create_from_xml(xml)
+        end
+      end
+    end
+  end
+end

--- a/lib/vbms/requests/list_contentions.rb
+++ b/lib/vbms/requests/list_contentions.rb
@@ -42,7 +42,6 @@ module VBMS
       end
 
       def handle_response(doc)
-        puts doc.to_xml
         doc.xpath(
           "//claimV4:listContentionsResponse/claimV4:listOfContentions",
           VBMS::XML_NAMESPACES

--- a/lib/vbms/requests/list_contentions.rb
+++ b/lib/vbms/requests/list_contentions.rb
@@ -1,0 +1,55 @@
+module VBMS
+  module Requests
+    class ListContentions < BaseRequest
+      NAMESPACES = {
+        "xmlns:cla" => "http://vbms.vba.va.gov/external/ClaimService/v4",
+        "xmlns:cdm" => "http://vbms.vba.va.gov/cdm/claim/v4",
+        "xmlns:participant" => "http://vbms.vba.va.gov/cdm/participant/v4"
+      }.freeze
+
+      def initialize(claim_id:)
+        @claim_id = claim_id
+      end
+
+      def name
+        "listContentions"
+      end
+
+      def endpoint_url(base_url)
+        "#{base_url}#{VBMS::ENDPOINTS[:claims]}"
+      end
+
+      def inject_header_content(header_xml)
+        Nokogiri::XML::Builder.with(header_xml) do |xml|
+          xml["vbmsext"].userId("dslogon.1011239249", "xmlns:vbmsext" => "http://vbms.vba.va.gov/external")
+        end
+      end
+
+      # More information on what the fields mean, see:
+      # https://github.com/department-of-veterans-affairs/dsva-vbms/issues/66#issuecomment-266098034
+      def soap_doc
+        VBMS::Requests.soap(more_namespaces: NAMESPACES) do |xml|
+          xml["cla"].listContentions do
+            xml["cla"].claimIdForListContentions @claim_id
+          end
+        end
+      end
+
+      def signed_elements
+        [["/soapenv:Envelope/soapenv:Body",
+          { soapenv: SoapScum::XMLNamespaces::SOAPENV },
+          "Content"]]
+      end
+
+      def handle_response(doc)
+        puts doc.to_xml
+        doc.xpath(
+          "//claimV4:listContentionsResponse/claimV4:listOfContentions",
+          VBMS::XML_NAMESPACES
+        ).map do |xml|
+          VBMS::Responses::Contention.create_from_xml(xml)
+        end
+      end
+    end
+  end
+end

--- a/lib/vbms/responses/contention.rb
+++ b/lib/vbms/responses/contention.rb
@@ -1,8 +1,8 @@
 module VBMS
   module Responses
     class Contention < OpenStruct
-      def self.create_from_xml(xml)
-        data = XMLHelper.convert_to_hash(xml.to_xml)[:list_of_contentions]
+      def self.create_from_xml(xml, key: :list_of_contentions)
+        data = XMLHelper.convert_to_hash(xml.to_xml)[key]
 
         new(
           id: data[:@id],

--- a/lib/vbms/responses/contention.rb
+++ b/lib/vbms/responses/contention.rb
@@ -1,24 +1,14 @@
 module VBMS
   module Responses
-    class Contention
-      attr_accessor :id, :text, :submit_date, :start_date
-  
-      def initialize(id:, text:, submit_date:, start_date:)
-        self.id = id
-        self.text = text
-        self.submit_date = submit_date
-        self.start_date = start_date
-      end
-  
+    class Contention < OpenStruct
       def self.create_from_xml(xml)
-        start_date = xml.at_xpath("ns0:startDate/text()", VBMS::XML_NAMESPACES)
-        submit_date = xml.at_xpath("ns0:submitDate/text()", VBMS::XML_NAMESPACES)
+        data = XMLHelper.convert_to_hash(xml.to_xml)[:list_of_contentions]
 
         new(
-          id: xml["id"],
-          text: xml["title"],
-          start_date: start_date && Time.parse(start_date.content).to_date,
-          submit_date: submit_date && Time.parse(submit_date.content).to_date
+          id: data[:@id],
+          text: data[:@title],
+          start_date: data[:start_date],
+          submit_date: data[:submit_date]
         )
       end
     end

--- a/lib/vbms/responses/contention.rb
+++ b/lib/vbms/responses/contention.rb
@@ -1,0 +1,26 @@
+module VBMS
+  module Responses
+    class Contention
+      attr_accessor :id, :text, :submit_date, :start_date
+  
+      def initialize(id:, text:, submit_date:, start_date:)
+        self.id = id
+        self.text = text
+        self.submit_date = submit_date
+        self.start_date = start_date
+      end
+  
+      def self.create_from_xml(xml)
+        start_date = xml.at_xpath("ns0:startDate/text()", VBMS::XML_NAMESPACES)
+        submit_date = xml.at_xpath("ns0:submitDate/text()", VBMS::XML_NAMESPACES)
+
+        new(
+          id: xml["id"],
+          text: xml["title"],
+          start_date: start_date && Time.parse(start_date.content).to_date,
+          submit_date: submit_date && Time.parse(submit_date.content).to_date
+        )
+      end
+    end
+  end
+end

--- a/spec/fixtures/responses/create_contentions.xml
+++ b/spec/fixtures/responses/create_contentions.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+  <env:Header>
+    <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+      <xenc:EncryptedKey xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" Id="EK-E75068198F8BAEFF36151136272550266316">
+        <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+        <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+          <wsse:SecurityTokenReference>
+            <ds:X509Data>
+              <ds:X509IssuerSerial>
+                <ds:X509IssuerName>CN=Scanning CA,OU=Scanning CA,O=Scanning CA,L=Culpeper,ST=Virginia,C=US</ds:X509IssuerName>
+                <ds:X509SerialNumber>49</ds:X509SerialNumber>
+              </ds:X509IssuerSerial>
+            </ds:X509Data>
+          </wsse:SecurityTokenReference>
+        </ds:KeyInfo>
+        <xenc:CipherData>
+          <xenc:CipherValue>JZE8rpkA/ZOAMm1iecgFMMLgEoCxm+Nq3xfof87eeR8GNsd7U0VpHtmUGBo5esJYRhzq1tDzvMG0u2sDQcP/cl+5bHgYO7GNjS70LO1JP/itVhnlpxPbw4HALVrH4aOtJRY0GeoT7LijApE3AAxKfuyF0ZHSNBmPhIh4gN2DozPGxJdv00alSSPScOEGQJzA6qWmUBYHNlIsHLdi9C3DoQ5e9+koZ2c08wImVSYKm7J9s8A4ZPHD5iClIUcE/bwGhCJ+AcV9HhkYpmFvOI+3/r4UQZRSkuM14iixkeXQFC/Mp6+3jjucminZy5GQtY6TtVyU2c0vMcWNR205SMRI3g==</xenc:CipherValue>
+        </xenc:CipherData>
+        <xenc:ReferenceList>
+          <xenc:DataReference URI="#ED-66316"/>
+        </xenc:ReferenceList>
+      </xenc:EncryptedKey>
+      <wsu:Timestamp wsu:Id="TS-66313">
+        <wsu:Created>2017-11-22T14:58:45.487Z</wsu:Created>
+        <wsu:Expires>2017-11-22T15:03:45.487Z</wsu:Expires>
+      </wsu:Timestamp>
+      <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="SIG-66315">
+        <ds:SignedInfo>
+          <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="env"/>
+          </ds:CanonicalizationMethod>
+          <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+          <ds:Reference URI="#TS-66313">
+            <ds:Transforms>
+              <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+                <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="wsse env"/>
+              </ds:Transform>
+            </ds:Transforms>
+            <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+            <ds:DigestValue>I0cWd+Bq0c86YgBMWZXKfd5GQA4=</ds:DigestValue>
+          </ds:Reference>
+          <ds:Reference URI="#id-66314">
+            <ds:Transforms>
+              <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+                <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList=""/>
+              </ds:Transform>
+            </ds:Transforms>
+            <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+            <ds:DigestValue>bUNINDx3NL7WSkKJ+z8GwtU565Y=</ds:DigestValue>
+          </ds:Reference>
+        </ds:SignedInfo>
+        <ds:SignatureValue>h/RXJrNFxtqEUgbIARAI3okKE4N1WGedMv3WxYL6Cosnshu5Pe6pHFLCM/E4bWkUBesgDuV2LJi2
+4+2Ee/7hS2JDvjT9n2pCZ8PAqHgonTCK/hmzRU3y+UQTWNn9w0EnXbsc15XqoTSwZcf45lk6EQJ0
+ky16OXK2FD2yyXMm6qR/wfk+wvEVWmNUOwRJF2xZM+AdTGVGj/zEIWvr72Fa/cUG0EMnO14U3kxC
+qgWN9ykIaXtSok/GFX/Ubk1+tgAl/TSVDNmRnwgS2SFmbYYmLZomEW9w3BCv9d/Af4SIVu8cjQNv
+Fs6ag2l8wZaSQCqX7tpi4SJ5bfsJojF+HVoclQ==</ds:SignatureValue>
+        <ds:KeyInfo Id="KI-E75068198F8BAEFF36151136272548766314">
+          <wsse:SecurityTokenReference wsu:Id="STR-E75068198F8BAEFF36151136272548766315">
+            <ds:X509Data>
+              <ds:X509IssuerSerial>
+                <ds:X509IssuerName>CN=AIDE CA2,OU=CA2,O=AIDE,L=Culpeper,ST=Virginia,C=US</ds:X509IssuerName>
+                <ds:X509SerialNumber>4</ds:X509SerialNumber>
+              </ds:X509IssuerSerial>
+            </ds:X509Data>
+          </wsse:SecurityTokenReference>
+        </ds:KeyInfo>
+      </ds:Signature>
+    </wsse:Security>
+  </env:Header>
+  <env:Body xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="id-66314">
+    <createContentionsResponse xmlns="http://vbms.vba.va.gov/external/ClaimService/v4" xmlns:ns0="http://vbms.vba.va.gov/cdm/claim/v4" xmlns:ns1="http://vbms.vba.va.gov/cdm/common/v4" xmlns:ns3="http://vbms.vba.va.gov/cdm/participant/v4" xmlns:ns4="http://vbms.vba.va.gov/external/ClaimService/v4"><ns4:createdContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290355" medical="false" partcipantContention="unknown" secondaryToContentionID="1498" title="Contention DS example" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:createdContentions><ns4:createdContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290356" medical="false" partcipantContention="unknown" secondaryToContentionID="1498" title="Contention DS example" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:createdContentions><ns4:createdContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290357" medical="false" partcipantContention="unknown" secondaryToContentionID="1498" title="Contention DS example" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:createdContentions><ns4:createdContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290358" medical="false" partcipantContention="unknown" secondaryToContentionID="1498" title="Billy Two" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:createdContentions><ns4:createdContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290359" medical="false" partcipantContention="unknown" secondaryToContentionID="1498" title="Contention DS example" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:createdContentions><ns4:createdContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290360" medical="false" partcipantContention="unknown" secondaryToContentionID="1498" title="Billy Two" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:createdContentions><ns4:createdContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290361" medical="false" partcipantContention="unknown" secondaryToContentionID="1498" title="Contention DS example" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:createdContentions><ns4:createdContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290362" medical="false" partcipantContention="unknown" secondaryToContentionID="1498" title="Billy Two" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:createdContentions><ns4:createdContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290363" medical="false" partcipantContention="unknown" secondaryToContentionID="1498" title="Billy One" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:createdContentions><ns4:createdContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290364" medical="false" partcipantContention="unknown" secondaryToContentionID="1498" title="Billy Two" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:createdContentions><ns4:createdContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290365" medical="false" partcipantContention="unknown" secondaryToContentionID="1498" title="Billy Three" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:createdContentions><ns4:createdContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290382" medical="false" partcipantContention="unknown" secondaryToContentionID="1498" title="Billy One" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-22-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:createdContentions></createContentionsResponse>
+  </env:Body>
+</env:Envelope>

--- a/spec/fixtures/responses/list_contentions.xml
+++ b/spec/fixtures/responses/list_contentions.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+  <env:Header>
+    <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+      <xenc:EncryptedKey xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" Id="EK-E75068198F8BAEFF36151136259280066288">
+        <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+        <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+          <wsse:SecurityTokenReference>
+            <ds:X509Data>
+              <ds:X509IssuerSerial>
+                <ds:X509IssuerName>CN=Scanning CA,OU=Scanning CA,O=Scanning CA,L=Culpeper,ST=Virginia,C=US</ds:X509IssuerName>
+                <ds:X509SerialNumber>49</ds:X509SerialNumber>
+              </ds:X509IssuerSerial>
+            </ds:X509Data>
+          </wsse:SecurityTokenReference>
+        </ds:KeyInfo>
+        <xenc:CipherData>
+          <xenc:CipherValue>RWn737fVFfa8v1urZzLoUkI/0HAo/C1KxWoH4ocLCDQdqsjdmHHa92Gc5vbfJfK7FfrlvmlCnrfbF6EanNz/OLx38b0DB4yqNUdevVyXQH1CPzwGy4VKw3lwrj514jH4jYopKv1V0Qi15205NkucZJ63jLYP+kTd+pYtsD30/5W49Gg27zJmcLqUbQMY5raD2dm0k0gZ5txW9jQVyYu4AnnrOjNezeckXzLJ/2FVykn2nHZK5J3j/5bsxzEzWM0+ZvT/kl4jjw9OhU2+1gPovjHNMnw1jitSrJJzO6GWw7guERlh56uJGf/ZKf4DffT6sSHVj5OYbzEbIaMuyONaEw==</xenc:CipherValue>
+        </xenc:CipherData>
+        <xenc:ReferenceList>
+          <xenc:DataReference URI="#ED-66288"/>
+        </xenc:ReferenceList>
+      </xenc:EncryptedKey>
+      <wsu:Timestamp wsu:Id="TS-66285">
+        <wsu:Created>2017-11-22T14:56:32.782Z</wsu:Created>
+        <wsu:Expires>2017-11-22T15:01:32.782Z</wsu:Expires>
+      </wsu:Timestamp>
+      <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="SIG-66287">
+        <ds:SignedInfo>
+          <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="env"/>
+          </ds:CanonicalizationMethod>
+          <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+          <ds:Reference URI="#TS-66285">
+            <ds:Transforms>
+              <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+                <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="wsse env"/>
+              </ds:Transform>
+            </ds:Transforms>
+            <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+            <ds:DigestValue>1CVuxyE5fnuqZ+DE5kH+uCYt5gA=</ds:DigestValue>
+          </ds:Reference>
+          <ds:Reference URI="#id-66286">
+            <ds:Transforms>
+              <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+                <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList=""/>
+              </ds:Transform>
+            </ds:Transforms>
+            <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+            <ds:DigestValue>73FISo6iY3Db00joF3g0TQUp188=</ds:DigestValue>
+          </ds:Reference>
+        </ds:SignedInfo>
+        <ds:SignatureValue>SjCgfRoZ2h5jPeSl59o/qVULHYgpQ2/N3IHdOUftD/QqcGLwPvKsIhOAhM7LiGLDQD2zxNSRmM+W
+PGeQryYhwarWQpnbNe1c4qudRvu31iSR7ol7DeklhhiXKMdjzdlveTqx5njlCxqA8+5MvetMlMPy
+ClqYOfoGLmClkhFxwfuv3GRxKUANG3EAx/zophPazbzjuC8gDwAF9ka+45gIQYlKpDV2FXxBXECA
+yZEY5pV595A8q4nIax4q6h5XL6NP4B5M/TQwNdhxCQQM7B7Q/wS+ulOwrmPNyDVoOybXOcxt10xR
+4JK/cDkNEV7eY4Ya6//+NdKydKhoOA5sZbNY6A==</ds:SignatureValue>
+        <ds:KeyInfo Id="KI-E75068198F8BAEFF36151136259278266286">
+          <wsse:SecurityTokenReference wsu:Id="STR-E75068198F8BAEFF36151136259278266287">
+            <ds:X509Data>
+              <ds:X509IssuerSerial>
+                <ds:X509IssuerName>CN=AIDE CA2,OU=CA2,O=AIDE,L=Culpeper,ST=Virginia,C=US</ds:X509IssuerName>
+                <ds:X509SerialNumber>4</ds:X509SerialNumber>
+              </ds:X509IssuerSerial>
+            </ds:X509Data>
+          </wsse:SecurityTokenReference>
+        </ds:KeyInfo>
+      </ds:Signature>
+    </wsse:Security>
+  </env:Header>
+  <env:Body xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="id-66286">
+    <listContentionsResponse xmlns="http://vbms.vba.va.gov/external/ClaimService/v4" xmlns:ns0="http://vbms.vba.va.gov/cdm/claim/v4" xmlns:ns1="http://vbms.vba.va.gov/cdm/common/v4" xmlns:ns3="http://vbms.vba.va.gov/cdm/participant/v4" xmlns:ns4="http://vbms.vba.va.gov/external/ClaimService/v4"><ns4:listOfContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290355" medical="false" partcipantContention="unknown" secondaryToContentionID="7792" title="Contention DS example" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:listOfContentions><ns4:listOfContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290356" medical="false" partcipantContention="unknown" secondaryToContentionID="7792" title="Contention DS example" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:listOfContentions><ns4:listOfContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290357" medical="false" partcipantContention="unknown" secondaryToContentionID="7792" title="Contention DS example" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:listOfContentions><ns4:listOfContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290358" medical="false" partcipantContention="unknown" secondaryToContentionID="7792" title="Billy Two" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:listOfContentions><ns4:listOfContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290359" medical="false" partcipantContention="unknown" secondaryToContentionID="7792" title="Contention DS example" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:listOfContentions><ns4:listOfContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290360" medical="false" partcipantContention="unknown" secondaryToContentionID="7792" title="Billy Two" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:listOfContentions><ns4:listOfContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290361" medical="false" partcipantContention="unknown" secondaryToContentionID="7792" title="Contention DS example" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:listOfContentions><ns4:listOfContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290362" medical="false" partcipantContention="unknown" secondaryToContentionID="7792" title="Billy Two" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:listOfContentions><ns4:listOfContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290363" medical="false" partcipantContention="unknown" secondaryToContentionID="7792" title="Billy One" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:listOfContentions><ns4:listOfContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290364" medical="false" partcipantContention="unknown" secondaryToContentionID="7792" title="Billy Two" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:listOfContentions><ns4:listOfContentions actionableItem="false" awaitingResponse="unknown" claimId="600118427" fileNumber="241573462" id="290365" medical="false" partcipantContention="unknown" secondaryToContentionID="7792" title="Billy Three" typeCode="NEW" workingContention="unknown"><ns0:source sourceName="VBMS_CMS"/><ns0:submitDate>2017-11-20-05:00</ns0:submitDate><ns0:startDate>2017-11-22-05:00</ns0:startDate></ns4:listOfContentions></listContentionsResponse>
+  </env:Body>
+</env:Envelope>

--- a/spec/requests/create_contentions_spec.rb
+++ b/spec/requests/create_contentions_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+describe VBMS::Requests::CreateContentions do
+  let(:request) do 
+    VBMS::Requests::CreateContentions.new(
+      veteran_file_number: "1232",
+      claim_id: "1323123",
+      contentions: ["Billy One", "Billy Two", "Billy Three"]
+    )
+  end
+
+  context "soap_doc" do
+    subject { request }
+
+    it "generates valid SOAP" do
+      xml = subject.soap_doc.to_xml
+      xsd = Nokogiri::XML::Schema(fixture("soap.xsd"))
+      expect(xsd.errors).to eq []
+      errors = xsd.validate(parse_strict(xml))
+      expect(errors).to eq []
+    end
+  end
+
+  context "parsing the XML response" do
+    let(:doc) { parse_strict(fixture("responses/create_contentions.xml")) }
+    subject { request.handle_response(doc) }
+
+    it "should return an array of contentions" do
+      puts subject
+      expect(subject).to be_an(Array)
+      expect(subject.count).to be 12
+    end
+
+    it "should load contents correctly" do
+      contention = subject.first
+      expect(contention.id).to eq "290355"
+      expect(contention.text).to eq "Contention DS example"
+    end
+  end
+end

--- a/spec/requests/list_contentions_spec.rb
+++ b/spec/requests/list_contentions_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+describe VBMS::Requests::ListContentions do
+  let(:request) do 
+    VBMS::Requests::ListContentions.new(claim_id: "1323123")
+  end
+
+  context "soap_doc" do
+    subject { request }
+
+    it "generates valid SOAP" do
+      xml = subject.soap_doc.to_xml
+      xsd = Nokogiri::XML::Schema(fixture("soap.xsd"))
+      expect(xsd.errors).to eq []
+      errors = xsd.validate(parse_strict(xml))
+      expect(errors).to eq []
+    end
+  end
+
+  context "parsing the XML response" do
+    let(:doc) { parse_strict(fixture("responses/list_contentions.xml")) }
+    subject { request.handle_response(doc) }
+
+    it "should return an array of contentions" do
+      puts subject
+      expect(subject).to be_an(Array)
+      expect(subject.count).to be 11
+    end
+
+    it "should load contents correctly" do
+      contention = subject.first
+      expect(contention.id).to eq "290355"
+      expect(contention.text).to eq "Contention DS example"
+    end
+  end
+end


### PR DESCRIPTION
Added `ListContentions` and `CreateContentions` as new requests.

Tested locally connected to VBMS.

To test:

```
> irb -Ilib

require "vbms"
c = VBMS::Client.from_env_vars(env_name: ENV["CONNECT_VBMS_ENV"])

r =  VBMS::Requests::CreateContentions.new(
      veteran_file_number: "241573462",
      claim_id: "600118427",
      contentions: ["Billy One", "Billy Two", "Billy Three"]
)
c.send_request(r)

r =  VBMS::Requests::ListContentions.new(
      claim_id: "600118427"
)
c.send_request(r)
```