### PR TITLE
Service Headers for Envoy

### DIFF
--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -75,7 +75,9 @@ module VBMS
 
       # If we have a sidecar proxy enabled, send the request to the
       # proxy URL instead of directly to VBMS.
-      url = @use_forward_proxy ? request.endpoint_url("#{@proxy_base_url}/#{request.name}") : request.endpoint_url(@base_url)
+      # the proxy uses 'envoy-prefix-requestName' to gather metrics
+      # https://www.envoyproxy.io/docs/envoy/latest/api-v1/route_config/vcluster.html
+      url = @use_forward_proxy ? request.endpoint_url("#{@proxy_base_url}/envoy-prefix-#{request.name}") : request.endpoint_url(@base_url)
       headers = { "Content-Type" => content_type(request) }
       http_request = build_request(url,
                                    body, headers)

--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -75,8 +75,8 @@ module VBMS
 
       # If we have a sidecar proxy enabled, send the request to the
       # proxy URL instead of directly to VBMS.
-      url = @use_forward_proxy ? request.endpoint_url(@proxy_base_url) : request.endpoint_url(@base_url)
-      headers = { "Content-Type" => content_type(request), "Service" => request.name.to_s }
+      url = @use_forward_proxy ? request.endpoint_url("#{@proxy_base_url}/#{request.name}") : request.endpoint_url(@base_url)
+      headers = { "Content-Type" => content_type(request) }
       http_request = build_request(url,
                                    body, headers)
 

--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -155,8 +155,8 @@ module VBMS
         headers["Host"] = @base_url.gsub("https://", "").gsub("http://", "")
       end
 
-      headers.merge({"service" => request.name.to_s})
       request = HTTPI::Request.new(endpoint_url)
+      headers.merge({"service" => request.name.to_s})
 
       request.open_timeout               = 300 # seconds
       request.read_timeout               = 300 # seconds

--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -76,7 +76,7 @@ module VBMS
       # If we have a sidecar proxy enabled, send the request to the
       # proxy URL instead of directly to VBMS.
       url = @use_forward_proxy ? request.endpoint_url(@proxy_base_url) : request.endpoint_url(@base_url)
-      headers = { "Content-Type" => content_type(request), "service" => request.name.to_s }
+      headers = { "Content-Type" => content_type(request), "Service" => request.name.to_s }
       http_request = build_request(url,
                                    body, headers)
 

--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -155,6 +155,7 @@ module VBMS
         headers["Host"] = @base_url.gsub("https://", "").gsub("http://", "")
       end
 
+      headers.merge({request.name.to_s})
       request = HTTPI::Request.new(endpoint_url)
 
       request.open_timeout               = 300 # seconds

--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -76,8 +76,9 @@ module VBMS
       # If we have a sidecar proxy enabled, send the request to the
       # proxy URL instead of directly to VBMS.
       url = @use_forward_proxy ? request.endpoint_url(@proxy_base_url) : request.endpoint_url(@base_url)
+      headers = {"Content-Type" => content_type(request), "service" => request.name.to_s}
       http_request = build_request(url,
-                                   body, "Content-Type" => content_type(request))
+                                   body, )
 
       HTTPI.log = false
       response = HTTPI.post(http_request)
@@ -156,7 +157,6 @@ module VBMS
       end
 
       request = HTTPI::Request.new(endpoint_url)
-      headers.merge({"service" => request.name.to_s})
 
       request.open_timeout               = 300 # seconds
       request.read_timeout               = 300 # seconds

--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -76,7 +76,7 @@ module VBMS
       # If we have a sidecar proxy enabled, send the request to the
       # proxy URL instead of directly to VBMS.
       url = @use_forward_proxy ? request.endpoint_url(@proxy_base_url) : request.endpoint_url(@base_url)
-      headers = {"Content-Type" => content_type(request), "service" => request.name.to_s}
+      headers = { "Content-Type" => content_type(request), "service" => request.name.to_s }
       http_request = build_request(url,
                                    body, headers)
 

--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -158,8 +158,8 @@ module VBMS
 
       request = HTTPI::Request.new(endpoint_url)
 
-      request.open_timeout               = 300 # seconds
-      request.read_timeout               = 300 # seconds
+      request.open_timeout               = 600 # seconds
+      request.read_timeout               = 600 # seconds
       request.auth.ssl.cert_key          = SoapScum::WSSecurity.client_key
       request.auth.ssl.cert_key_password = @keypass
       request.auth.ssl.cert              = SoapScum::WSSecurity.client_cert

--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -155,7 +155,7 @@ module VBMS
         headers["Host"] = @base_url.gsub("https://", "").gsub("http://", "")
       end
 
-      headers.merge({request.name.to_s})
+      headers.merge({"service" => request.name.to_s})
       request = HTTPI::Request.new(endpoint_url)
 
       request.open_timeout               = 300 # seconds

--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -78,7 +78,7 @@ module VBMS
       url = @use_forward_proxy ? request.endpoint_url(@proxy_base_url) : request.endpoint_url(@base_url)
       headers = {"Content-Type" => content_type(request), "service" => request.name.to_s}
       http_request = build_request(url,
-                                   body, )
+                                   body, headers)
 
       HTTPI.log = false
       response = HTTPI.post(http_request)

--- a/lib/vbms/requests/list_contentions.rb
+++ b/lib/vbms/requests/list_contentions.rb
@@ -7,7 +7,7 @@ module VBMS
         "xmlns:participant" => "http://vbms.vba.va.gov/cdm/participant/v4"
       }.freeze
 
-      def initialize(claim_id:)
+      def initialize(claim_id)
         @claim_id = claim_id
       end
 

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -58,9 +58,10 @@ describe VBMS::Requests do
           true
         )
 
-        webmock_multipart_response("http://localhost:3000#{VBMS::ENDPOINTS[:efolder]}",
-                                   "upload_document_with_associations",
-                                   "uploadDocumentWithAssociationsResponse")
+        webmock_multipart_response(
+          "http://localhost:3000/envoy-prefix-uploadDocumentWithAssociations/vbmsp2-cms/streaming/eDocumentService-v4",
+          "upload_document_with_associations",
+          "uploadDocumentWithAssociationsResponse")
         @client.send_request(request)
       end
     end


### PR DESCRIPTION
this way Envoy can route match by headers and get metrics for each service:
https://www.envoyproxy.io/docs/envoy/latest/api-v1/route_config/route.html#config-http-conn-man-route-table-route-headers

```
POST /vbmsp2-cms/streaming/eDocumentService-v4 HTTP/1.1
Content-Type: text/xml;charset=UTF-8
service: getDocumentTypes
Host: filenet.uat.vbms.aide.oit.va.gov
User-Agent: HTTPClient/1.0 (2.8.3, ruby 2.3.0 (2015-12-25))
Accept: */*
Date: Sat, 02 Dec 2017 22:54:07 GMT
Content-Length: 13476
```

## To test:
- set up the gem to use forward proxy
- tcpdump the headers to see the `service` header as shown above