### PR TITLE
Return type_id for ListDocuments

### DIFF
--- a/lib/vbms/responses/document.rb
+++ b/lib/vbms/responses/document.rb
@@ -1,11 +1,11 @@
 module VBMS
   module Responses
     class Document
-      attr_accessor :document_id, :filename, :doc_type, :source, :received_at, :mime_type, :alt_doc_types
-  
+      attr_accessor :document_id, :filename, :doc_type, :source, :received_at, :mime_type, :alt_doc_types, :type_id
+
       def initialize(
           document_id: nil, filename: nil, doc_type: nil, source: nil,
-          received_at: nil, mime_type: nil, alt_doc_types: nil)
+          received_at: nil, mime_type: nil, alt_doc_types: nil, type_id: nil)
         self.document_id = document_id
         self.filename = filename
         self.doc_type = doc_type
@@ -13,8 +13,9 @@ module VBMS
         self.received_at = received_at
         self.mime_type = mime_type
         self.alt_doc_types = alt_doc_types
+        self.type_id = type_id
       end
-  
+
       def self.create_from_xml(el)
         received_date = el.at_xpath("ns2:receivedDt/text()", VBMS::XML_NAMESPACES)
 
@@ -24,6 +25,7 @@ module VBMS
             alt_doc_types: extract_alt_doc_types(el),
             source: el["source"],
             mime_type: el["mimeType"],
+            type_id: el["docType"],
             received_at: received_date.nil? ? nil : Time.parse(received_date.content).to_date)
       end
 
@@ -43,7 +45,8 @@ module VBMS
           doc_type: doc_type,
           source: source,
           received_at: received_at,
-          mime_type: mime_type
+          mime_type: mime_type,
+          type_id: type_id
         }
       end
 

--- a/spec/responses/document_spec.rb
+++ b/spec/responses/document_spec.rb
@@ -12,6 +12,7 @@ describe VBMS::Responses::Document do
     specify { expect(subject.document_id).to eq("{9E364101-AFDD-49A7-A11F-602CCF2E5DB5}") }
     specify { expect(subject.filename).to eq("tmp20150506-94244-6zotzp") }
     specify { expect(subject.doc_type).to eq("356") }
+    specify { expect(subject.type_id).to eq("356") }
     specify { expect(subject.source).to eq("VHA_CUI") }
     specify { expect(subject.mime_type).to eq("text/plain") }
     specify { expect(subject.received_at).to eq(Date.parse("2015-05-06")) }
@@ -25,8 +26,8 @@ describe VBMS::Responses::Document do
 
   describe "serialization" do
     let(:attrs) do
-      { document_id: "{9E364101-AFDD-49A7-A11F-602CCF2E5DB5}", filename: "tmp20150506-94244-6zotzp", 
-        doc_type: "356", source: "VHA_CUI", mime_type: "text/plain", received_at: Time.now }
+      { document_id: "{9E364101-AFDD-49A7-A11F-602CCF2E5DB5}", filename: "tmp20150506-94244-6zotzp",
+        doc_type: "356", source: "VHA_CUI", mime_type: "text/plain", received_at: Time.now, type_id: "356" }
     end
     subject { VBMS::Responses::Document.new(attrs) }
 
@@ -45,6 +46,7 @@ describe VBMS::Responses::Document do
       expect(s).to include(attrs[:filename])
       expect(s).to include(attrs[:doc_type])
       expect(s).to include(attrs[:source])
+      expect(s).to include(attrs[:type_id])
     end
 
     it "should respond to inspect" do


### PR DESCRIPTION
Since eX v2 will still be using VBMS old API for some time, I added `type_id` to the ListDocument response so we can avoid this check: https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/master/app/services/download_documents.rb#L41