### PR TITLE
Update findDocumentSeriesReference to return array

### DIFF
--- a/lib/vbms/helpers/xml_helper.rb
+++ b/lib/vbms/helpers/xml_helper.rb
@@ -32,6 +32,11 @@ module XMLHelper
     versions.is_a?(Array) ? sort_versions(versions) : versions
   end
 
+  # If there is only one version we make an array out of it so we can map over it.
+  def self.versions_as_array(versions)
+    versions.is_a?(Array) ? versions : [versions]
+  end
+
   def self.remove_namespaces(nodes)
     nodes.each { |node| node.namespace = nil }
   end

--- a/lib/vbms/requests/find_document_series_reference.rb
+++ b/lib/vbms/requests/find_document_series_reference.rb
@@ -40,7 +40,9 @@ module VBMS
           "//read:findDocumentSeriesReferenceResponse/read:result", VBMS::XML_NAMESPACES
         ).map do |el|
           result = XMLHelper.convert_to_hash(el.to_xml)[:result]
-          construct_response(XMLHelper.most_recent_version(result[:versions]))
+          result[:versions].map do |version|
+            construct_response(version)
+          end
         end
       end
 

--- a/lib/vbms/requests/find_document_series_reference.rb
+++ b/lib/vbms/requests/find_document_series_reference.rb
@@ -40,7 +40,7 @@ module VBMS
           "//read:findDocumentSeriesReferenceResponse/read:result", VBMS::XML_NAMESPACES
         ).map do |el|
           result = XMLHelper.convert_to_hash(el.to_xml)[:result]
-          result[:versions].map do |version|
+          XMLHelper.versions_as_array(result[:versions]).map do |version|
             construct_response(version)
           end
         end

--- a/spec/helpers/xml_helper_spec.rb
+++ b/spec/helpers/xml_helper_spec.rb
@@ -46,4 +46,27 @@ describe XMLHelper do
       it { is_expected.to eq(version: { :@major => "88" }) }
     end
   end
+
+  context ".versions_as_array" do
+    let(:h1) { { version: { :@major => "45" } } }
+    let(:h2) { { version: { :@major => "88" } } }
+    let(:h3) { { version: nil } }
+
+    subject { XMLHelper.versions_as_array(versions) }
+
+    context "when versions is an array" do
+      let(:versions) { [h1, h2] }
+      it { is_expected.to eq(versions) }
+    end
+
+    context "when versions is a hash" do
+      let(:versions) { h1 }
+      it { is_expected.to eq([versions]) }
+    end
+
+    context "when version is nil" do
+      let(:versions) { [h1, h3, h2] }
+      it { is_expected.to eq(versions) }
+    end
+  end
 end

--- a/spec/requests/find_document_series_reference_spec.rb
+++ b/spec/requests/find_document_series_reference_spec.rb
@@ -29,7 +29,7 @@ describe VBMS::Requests::FindDocumentSeriesReference do
 
     it "should load contents correctly" do
       # document with multiple versions
-      doc1 = subject.first
+      doc1 = subject.first.first
       expect(doc1[:document_id]).to eq "{68A9F5E8-8937-4106-96AE-7066E1FC0E15}"
       expect(doc1[:series_id]).to eq "{95FD13DE-5ADD-488F-BF45-50C0993AEE34}"
       expect(doc1[:version]).to eq "2"
@@ -41,7 +41,7 @@ describe VBMS::Requests::FindDocumentSeriesReference do
       expect(doc1[:received_at]).to eq Date.parse("2014-11-16-04:00")
 
       # document with alt doc types and one version
-      doc2 = subject.third
+      doc2 = subject.third.first
       expect(doc2[:alt_doc_types].size).to eq 4
       expect(doc2[:document_id]).to eq "{9909502E-E797-421C-BE2F-7650E2F2E7F1}"
       expect(doc2[:type_description]).to eq "Substantive Appeal (In Lieu of VA Form 9)"
@@ -50,8 +50,8 @@ describe VBMS::Requests::FindDocumentSeriesReference do
       expect(doc2[:restricted]).to eq true
       expect(doc2[:received_at]).to eq Date.parse("2014-04-30-04:00")
 
-      doc3 = subject.fourth
-      expect(doc3[:document_id]).to eq "{00E04F55-0000-C182-A5AC-FD645B3C9315}"
+      doc3 = subject.fourth.first
+      expect(doc3[:document_id]).to eq "{C7A6DA43-A368-4831-A68B-D32F0C164C22}"
       expect(doc3[:restricted]).to eq false
     end
   end

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -173,7 +173,7 @@ describe VBMS::Requests do
                             "findDocumentSeriesReferenceResponse")
       result = @client.send_request(request)
 
-      request = VBMS::Requests::GetDocumentContent.new(result[0][:document_id])
+      request = VBMS::Requests::GetDocumentContent.new(result[0][0][:document_id])
       webmock_soap_response("#{@client.base_url}#{VBMS::ENDPOINTS[:efolder_svc_v1][:read]}",
                             "get_document_content",
                             "getDocumentContentResponse")


### PR DESCRIPTION
We want FindDocumentSeriesReference to return an array of versions instead of a single version so that we can associate old document ids with the new series id.

**Test Plan**
- [ ] In Preprod run: 
```
client = VBMS::Client.from_env_vars(
      logger: VBMSCaseflowLogger.new,
      env_name: ENV["CONNECT_VBMS_ENV"],
      use_forward_proxy: FeatureToggle.enabled?(:vbms_forward_proxy)
    )

request = VBMS::Requests::FindDocumentSeriesReference.new("123123123")
client.send_request(request)
```
You should see an array of arrays of OpenStructs