### PR TITLE
Upgrade Nokogiri dependency to mitigate vulnerability

### DIFF
--- a/connect_vbms.gemspec
+++ b/connect_vbms.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "httpclient", "~> 2.8.0"
   spec.add_runtime_dependency "httpi", "~> 2.4"
-  spec.add_runtime_dependency "nokogiri", ">= 1.8.1"
+  spec.add_runtime_dependency "nokogiri", ">= 1.8.2"
   spec.add_runtime_dependency "xmlenc"
   spec.add_runtime_dependency "mail"
   spec.add_runtime_dependency "xmldsig", "~> 0.3.1"

--- a/lib/vbms/version.rb
+++ b/lib/vbms/version.rb
@@ -9,7 +9,7 @@ module VBMS
 
   # Current patch level.
   # @return [Integer]
-  PATCH = 0
+  PATCH = 1
 
   # Full release version.
   # @return [String]


### PR DESCRIPTION
Upgrade Nokogiri to mitigate disclosed vulnerability [as recommended](https://github.com/sparklemotion/nokogiri/issues/1714) by the Nokogiri maintainers.