### PR TITLE
Allow CSS user information to be injected into the saml token

### DIFF
--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -40,7 +40,7 @@ module VBMS
         ca_cert: env_path(env_dir, "CONNECT_VBMS_CACERT", allow_empty: true),
         saml: env_path(env_dir, "CONNECT_VBMS_SAML"),
         use_forward_proxy: use_forward_proxy,
-        proxy_base_url: get_env("CONNECT_VBMS_PROXY_BASE_URL"),
+        proxy_base_url: get_env("CONNECT_VBMS_PROXY_BASE_URL", allow_empty: true),
         logger: logger
       )
     end

--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -9,6 +9,8 @@ module VBMS
                    ca_cert: nil,
                    saml:,
                    logger: nil,
+                   css_id: nil,
+                   station_id: nil,
                    proxy_base_url: nil,
                    use_forward_proxy: false)
 
@@ -19,6 +21,8 @@ module VBMS
       @cacert = ca_cert
       @server_key = server_cert
       @logger = logger
+      @css_id = css_id
+      @station_id = station_id
       @proxy_base_url = proxy_base_url
       @use_forward_proxy = use_forward_proxy
 
@@ -29,7 +33,7 @@ module VBMS
       )
     end
 
-    def self.from_env_vars(logger: nil, env_name: "test", use_forward_proxy: false)
+    def self.from_env_vars(logger: nil, css_id: nil, station_id: nil, env_name: "test", use_forward_proxy: false)
       env_dir = File.join(get_env("CONNECT_VBMS_ENV_DIR"), env_name)
 
       VBMS::Client.new(
@@ -118,10 +122,27 @@ module VBMS
 
     def inject_saml(doc)
       saml_doc = Nokogiri::XML(File.read(@saml)).root
+
+      inject_user_into_saml(saml_doc)
+
       doc.at_xpath(
         "//wsse:Security",
         wsse: "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
       ) << saml_doc
+    end
+
+    def inject_user_into_saml(saml_doc)
+      if @css_id && @station_id
+        saml_doc.at_xpath(
+          "//saml2:Attribute[@Name ='http://vba.va.gov/css/common/subjectId']/saml2:AttributeValue",
+          "xmlns:saml2" => 'urn:oasis:names:tc:SAML:2.0:assertion'
+        ).child.replace(@css_id)
+
+        saml_doc.at_xpath(
+          "//saml2:Attribute[@Name ='http://vba.va.gov/css/common/stationId']/saml2:AttributeValue",
+          "xmlns:saml2" => 'urn:oasis:names:tc:SAML:2.0:assertion'
+        ).child.replace(@station_id)
+      end
     end
 
     def inject_header_content(doc, request)

--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -43,6 +43,8 @@ module VBMS
         server_cert: env_path(env_dir, "CONNECT_VBMS_SERVER_CERT", allow_empty: true),
         ca_cert: env_path(env_dir, "CONNECT_VBMS_CACERT", allow_empty: true),
         saml: env_path(env_dir, "CONNECT_VBMS_SAML"),
+        css_id: css_id,
+        station_id: station_id,
         use_forward_proxy: use_forward_proxy,
         proxy_base_url: get_env("CONNECT_VBMS_PROXY_BASE_URL", allow_empty: true),
         logger: logger
@@ -135,12 +137,12 @@ module VBMS
       if @css_id && @station_id
         saml_doc.at_xpath(
           "//saml2:Attribute[@Name ='http://vba.va.gov/css/common/subjectId']/saml2:AttributeValue",
-          "xmlns:saml2" => 'urn:oasis:names:tc:SAML:2.0:assertion'
+          "xmlns:saml2" => "urn:oasis:names:tc:SAML:2.0:assertion"
         ).child.replace(@css_id)
 
         saml_doc.at_xpath(
           "//saml2:Attribute[@Name ='http://vba.va.gov/css/common/stationId']/saml2:AttributeValue",
-          "xmlns:saml2" => 'urn:oasis:names:tc:SAML:2.0:assertion'
+          "xmlns:saml2" => "urn:oasis:names:tc:SAML:2.0:assertion"
         ).child.replace(@station_id)
       end
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -23,14 +23,14 @@ describe VBMS::Client do
     let(:injected_css_id) do
       doc.at_xpath(
         "//saml2:Attribute[@Name ='http://vba.va.gov/css/common/subjectId']/saml2:AttributeValue",
-        "xmlns:saml2" => 'urn:oasis:names:tc:SAML:2.0:assertion'
+        "xmlns:saml2" => "urn:oasis:names:tc:SAML:2.0:assertion"
       ).child.text
     end
 
     let(:injected_station_id) do
       doc.at_xpath(
         "//saml2:Attribute[@Name ='http://vba.va.gov/css/common/stationId']/saml2:AttributeValue",
-        "xmlns:saml2" => 'urn:oasis:names:tc:SAML:2.0:assertion'
+        "xmlns:saml2" => "urn:oasis:names:tc:SAML:2.0:assertion"
       ).child.text
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -151,13 +151,15 @@ def parsed_timestamp(xml)
 end
 
 # to generate test files, run rake fixtures
-def new_test_client(use_forward_proxy: false)
+def new_test_client(css_id: nil, station_id: nil, use_forward_proxy: false)
   VBMS::Client.new(
     base_url: "http://test.endpoint.url/",
     keypass: "importkey",
     client_keyfile: fixture_path("test_client.p12"),
     server_cert: fixture_path("test_server.crt"),
     saml: fixture_path("test_samltoken.xml"),
+    css_id: css_id,
+    station_id: station_id,
     use_forward_proxy: use_forward_proxy,
     proxy_base_url: use_forward_proxy ? "http://localhost:3000" : nil
   )


### PR DESCRIPTION
This is the first step to sending user data with VBMS calls.

It defaults to the old way and should not affect the current way the service is used.