### PR TITLE
[WIP] Update rubocop dependency to mitigate security vulnerability

### DIFF
--- a/connect_vbms.gemspec
+++ b/connect_vbms.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.3"
   spec.add_development_dependency "equivalent-xml", "~> 0.6"
   spec.add_development_dependency "simplecov", "~> 0.10"
-  spec.add_development_dependency "rubocop", "0.36"
+  spec.add_development_dependency "rubocop", "0.49"
   spec.add_development_dependency "bundler-audit"
   spec.add_development_dependency "webmock", "~> 1.22.0"
   spec.add_development_dependency "byebug" if RUBY_PLATFORM != "java"


### PR DESCRIPTION
> RuboCop 0.48.1 and earlier does not use /tmp in safe way

reference : 
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418 
- https://github.com/bbatsov/rubocop/issues/4336