### PR TITLE
send orig src only in v5

### DIFF
--- a/lib/vbms/requests/create_contentions.rb
+++ b/lib/vbms/requests/create_contentions.rb
@@ -66,7 +66,7 @@ module VBMS
                 partcipantContention: "unused, but required."
               ) do
                 xml["cdm"].submitDate Date.today.iso8601
-                xml["cdm"].origSrc "APP"
+                xml["cdm"].origSrc "APP" if @v5
 
                 @special_issues.each do |special_issue|
                   xml["cdm"].issue(


### PR DESCRIPTION
This was causing #198 from a bug in department-of-veterans-affairs/caseflow#6251