### PR TITLE
Move issues to before origSrc

### DIFF
--- a/lib/vbms/requests/create_contentions.rb
+++ b/lib/vbms/requests/create_contentions.rb
@@ -66,7 +66,6 @@ module VBMS
                 partcipantContention: "unused, but required."
               ) do
                 xml["cdm"].submitDate Date.today.iso8601
-                xml["cdm"].origSrc "APP" if @v5
 
                 @special_issues.each do |special_issue|
                   xml["cdm"].issue(
@@ -75,6 +74,8 @@ module VBMS
                     inferred: "false"
                   )
                 end
+                
+                xml["cdm"].origSrc "APP" if @v5
               end
             end
           end


### PR DESCRIPTION
connects https://github.com/department-of-veterans-affairs/caseflow/issues/5281

After we added origSrc, setting the same office stopped working.  Based on conversation with VBMS it seems that the order of the data matters, and that the issues should come before setting the same office special issue.