### PR TITLE
adding user id & station

### DIFF
--- a/lib/vbms.rb
+++ b/lib/vbms.rb
@@ -26,6 +26,7 @@ require "vbms/responses/contention"
 require "vbms/responses/disposition"
 
 require "vbms/requests/base_request"
+require "vbms/requests/add_ext_security_header"
 # eDocument Service v4
 require "vbms/requests/upload_document_with_associations"
 require "vbms/requests/list_documents"

--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -151,6 +151,14 @@ module VBMS
 
     def inject_header_content(doc, request)
       request.inject_header_content(doc.at_xpath("/soapenv:Envelope/soapenv:Header"))
+
+      # replace user headers if needed
+      user_element = doc.at_xpath("//etc:cssUserName", "etc" => "http://vbms.vba.va.gov/external")
+      station_element = doc.at_xpath("//etc:cssStationId", "etc" => "http://vbms.vba.va.gov/external")
+      @css_id && user_element && user_element.content = @css_id
+      @station_id && station_element && station_element.content = @station_id
+
+      doc
     end
 
     def remove_must_understand(doc)

--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -9,8 +9,6 @@ module VBMS
                    ca_cert: nil,
                    saml:,
                    logger: nil,
-                   css_id: nil,
-                   station_id: nil,
                    proxy_base_url: nil,
                    use_forward_proxy: false)
 
@@ -21,8 +19,6 @@ module VBMS
       @cacert = ca_cert
       @server_key = server_cert
       @logger = logger
-      @css_id = css_id
-      @station_id = station_id
       @proxy_base_url = proxy_base_url
       @use_forward_proxy = use_forward_proxy
 
@@ -33,7 +29,7 @@ module VBMS
       )
     end
 
-    def self.from_env_vars(logger: nil, css_id: nil, station_id: nil, env_name: "test", use_forward_proxy: false)
+    def self.from_env_vars(logger: nil, env_name: "test", use_forward_proxy: false)
       env_dir = File.join(get_env("CONNECT_VBMS_ENV_DIR"), env_name)
 
       VBMS::Client.new(
@@ -43,8 +39,6 @@ module VBMS
         server_cert: env_path(env_dir, "CONNECT_VBMS_SERVER_CERT", allow_empty: true),
         ca_cert: env_path(env_dir, "CONNECT_VBMS_CACERT", allow_empty: true),
         saml: env_path(env_dir, "CONNECT_VBMS_SAML"),
-        css_id: css_id,
-        station_id: station_id,
         use_forward_proxy: use_forward_proxy,
         proxy_base_url: get_env("CONNECT_VBMS_PROXY_BASE_URL", allow_empty: true),
         logger: logger
@@ -126,27 +120,10 @@ module VBMS
 
     def inject_saml(doc)
       saml_doc = Nokogiri::XML(File.read(@saml)).root
-
-      inject_user_into_saml(saml_doc)
-
       doc.at_xpath(
         "//wsse:Security",
         wsse: "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
       ) << saml_doc
-    end
-
-    def inject_user_into_saml(saml_doc)
-      if @css_id && @station_id
-        saml_doc.at_xpath(
-          "//saml2:Attribute[@Name ='http://vba.va.gov/css/common/subjectId']/saml2:AttributeValue",
-          "xmlns:saml2" => "urn:oasis:names:tc:SAML:2.0:assertion"
-        ).child.replace(@css_id)
-
-        saml_doc.at_xpath(
-          "//saml2:Attribute[@Name ='http://vba.va.gov/css/common/stationId']/saml2:AttributeValue",
-          "xmlns:saml2" => "urn:oasis:names:tc:SAML:2.0:assertion"
-        ).child.replace(@station_id)
-      end
     end
 
     def inject_header_content(doc, request)

--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -138,8 +138,8 @@ module VBMS
       # replace user headers if needed
       user_element = doc.at_xpath("//etc:cssUserName", "etc" => "http://vbms.vba.va.gov/external")
       station_element = doc.at_xpath("//etc:cssStationId", "etc" => "http://vbms.vba.va.gov/external")
-      @css_id && user_element && user_element.content = @css_id
-      @station_id && station_element && station_element.content = @station_id
+      user_element.content = @css_id if @css_id && user_element
+      station_element.content = @station_id if @station_id && station_element
 
       doc
     end

--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -9,6 +9,8 @@ module VBMS
                    ca_cert: nil,
                    saml:,
                    logger: nil,
+                   css_id: nil,
+                   station_id: nil,
                    proxy_base_url: nil,
                    use_forward_proxy: false)
 
@@ -19,6 +21,8 @@ module VBMS
       @cacert = ca_cert
       @server_key = server_cert
       @logger = logger
+      @css_id = css_id
+      @station_id = station_id
       @proxy_base_url = proxy_base_url
       @use_forward_proxy = use_forward_proxy
 
@@ -29,7 +33,7 @@ module VBMS
       )
     end
 
-    def self.from_env_vars(logger: nil, env_name: "test", use_forward_proxy: false)
+    def self.from_env_vars(logger: nil, css_id: nil, station_id: nil, env_name: "test", use_forward_proxy: false)
       env_dir = File.join(get_env("CONNECT_VBMS_ENV_DIR"), env_name)
 
       VBMS::Client.new(
@@ -39,6 +43,8 @@ module VBMS
         server_cert: env_path(env_dir, "CONNECT_VBMS_SERVER_CERT", allow_empty: true),
         ca_cert: env_path(env_dir, "CONNECT_VBMS_CACERT", allow_empty: true),
         saml: env_path(env_dir, "CONNECT_VBMS_SAML"),
+        css_id: css_id,
+        station_id: station_id,
         use_forward_proxy: use_forward_proxy,
         proxy_base_url: get_env("CONNECT_VBMS_PROXY_BASE_URL", allow_empty: true),
         logger: logger

--- a/lib/vbms/requests/add_ext_security_header.rb
+++ b/lib/vbms/requests/add_ext_security_header.rb
@@ -1,0 +1,14 @@
+module AddExtSecurityHeader
+  def inject_header_content(header_xml)
+    Nokogiri::XML::Builder.with(header_xml) do |xml|
+      xml["vbmsext"].userId("dslogon.1011239249", "xmlns:vbmsext" => "http://vbms.vba.va.gov/external")
+      if @send_userid
+        xml["ext"].Security("xmlns:ext" => "http://vbms.vba.va.gov/external") do
+          xml["ext"].cssUserName # do not insert css id in here, this will be injected by the client
+          xml["ext"].cssStationId
+          xml["ext"].SecurityLevel security_level
+        end
+      end
+    end
+  end
+end

--- a/lib/vbms/requests/base_request.rb
+++ b/lib/vbms/requests/base_request.rb
@@ -13,6 +13,11 @@ module VBMS
       def inject_header_content(xml)
         xml
       end
+
+      def security_level
+        # magic number for vbms
+        9
+      end
     end
   end
 end

--- a/lib/vbms/requests/create_contentions.rb
+++ b/lib/vbms/requests/create_contentions.rb
@@ -44,7 +44,7 @@ module VBMS
             xml["ext"].Security("xmlns:ext" => "http://vbms.vba.va.gov/external") do
               xml["ext"].cssUserName # do not insert css id in here, this will be injected by the client
               xml["ext"].cssStationId
-              xml["ext"].SecurityLevel 9
+              xml["ext"].SecurityLevel security_level
             end
           end
         end

--- a/lib/vbms/requests/create_contentions.rb
+++ b/lib/vbms/requests/create_contentions.rb
@@ -16,12 +16,13 @@ module VBMS
       # Contentions should be an array of strings representing the contentions
       # Special issues should be an array of hashes with the form:
       #   { code: "SSR", narrative: "Same Station Review" }
-      def initialize(veteran_file_number:, claim_id:, contentions:, special_issues: [], v5: false)
+      def initialize(veteran_file_number:, claim_id:, contentions:, special_issues: [], v5: false, send_userid: false)
         @veteran_file_number = veteran_file_number
         @claim_id = claim_id
         @contentions = contentions
         @special_issues = special_issues
         @v5 = v5
+        @send_userid = send_userid
       end
 
       def name
@@ -39,6 +40,13 @@ module VBMS
       def inject_header_content(header_xml)
         Nokogiri::XML::Builder.with(header_xml) do |xml|
           xml["vbmsext"].userId("dslogon.1011239249", "xmlns:vbmsext" => "http://vbms.vba.va.gov/external")
+          if @send_userid
+            xml["ext"].Security("xmlns:ext" => "http://vbms.vba.va.gov/external") do
+              xml["ext"].cssUserName # do not insert css id in here, this will be injected by the client
+              xml["ext"].cssStationId
+              xml["ext"].SecurityLevel 9
+            end
+          end
         end
       end
 

--- a/lib/vbms/requests/create_contentions.rb
+++ b/lib/vbms/requests/create_contentions.rb
@@ -1,6 +1,8 @@
 module VBMS
   module Requests
     class CreateContentions < BaseRequest
+      include AddExtSecurityHeader
+
       NAMESPACES = {
         "xmlns:cla" => "http://vbms.vba.va.gov/external/ClaimService/v4",
         "xmlns:cdm" => "http://vbms.vba.va.gov/cdm/claim/v4",
@@ -35,19 +37,6 @@ module VBMS
 
       def endpoint_url(base_url)
         "#{base_url}#{VBMS::ENDPOINTS[specify_endpoint]}"
-      end
-
-      def inject_header_content(header_xml)
-        Nokogiri::XML::Builder.with(header_xml) do |xml|
-          xml["vbmsext"].userId("dslogon.1011239249", "xmlns:vbmsext" => "http://vbms.vba.va.gov/external")
-          if @send_userid
-            xml["ext"].Security("xmlns:ext" => "http://vbms.vba.va.gov/external") do
-              xml["ext"].cssUserName # do not insert css id in here, this will be injected by the client
-              xml["ext"].cssStationId
-              xml["ext"].SecurityLevel security_level
-            end
-          end
-        end
       end
 
       def soap_doc

--- a/lib/vbms/requests/establish_claim.rb
+++ b/lib/vbms/requests/establish_claim.rb
@@ -13,10 +13,11 @@ module VBMS
         "xmlns:participant" => "http://vbms.vba.va.gov/cdm/participant/v5"
       }.freeze
 
-      def initialize(veteran_record, claim, v5: false)
+      def initialize(veteran_record, claim, v5: false, send_userid: false)
         @veteran_record = veteran_record
         @claim = claim
         @v5 = v5
+        @send_userid = send_userid
       end
 
       def name
@@ -34,6 +35,13 @@ module VBMS
       def inject_header_content(header_xml)
         Nokogiri::XML::Builder.with(header_xml) do |xml|
           xml["vbmsext"].userId("dslogon.1011239249", "xmlns:vbmsext" => "http://vbms.vba.va.gov/external")
+          if @send_userid
+            xml["ext"].Security("xmlns:ext" => "http://vbms.vba.va.gov/external") do
+              xml["ext"].cssUserName # do not insert css id in here, this will be injected by the client
+              xml["ext"].cssStationId
+              xml["ext"].SecurityLevel 9
+            end
+          end
         end
       end
 

--- a/lib/vbms/requests/establish_claim.rb
+++ b/lib/vbms/requests/establish_claim.rb
@@ -1,6 +1,8 @@
 module VBMS
   module Requests
     class EstablishClaim < BaseRequest
+      include AddExtSecurityHeader
+
       NAMESPACES = {
         "xmlns:cla" => "http://vbms.vba.va.gov/external/ClaimService/v4",
         "xmlns:cdm" => "http://vbms.vba.va.gov/cdm/claim/v4",
@@ -30,19 +32,6 @@ module VBMS
 
       def endpoint_url(base_url)
         "#{base_url}#{VBMS::ENDPOINTS[specify_endpoint]}"
-      end
-
-      def inject_header_content(header_xml)
-        Nokogiri::XML::Builder.with(header_xml) do |xml|
-          xml["vbmsext"].userId("dslogon.1011239249", "xmlns:vbmsext" => "http://vbms.vba.va.gov/external")
-          if @send_userid
-            xml["ext"].Security("xmlns:ext" => "http://vbms.vba.va.gov/external") do
-              xml["ext"].cssUserName # do not insert css id in here, this will be injected by the client
-              xml["ext"].cssStationId
-              xml["ext"].SecurityLevel security_level
-            end
-          end
-        end
       end
 
       # More information on what the fields mean, see:

--- a/lib/vbms/requests/establish_claim.rb
+++ b/lib/vbms/requests/establish_claim.rb
@@ -39,7 +39,7 @@ module VBMS
             xml["ext"].Security("xmlns:ext" => "http://vbms.vba.va.gov/external") do
               xml["ext"].cssUserName # do not insert css id in here, this will be injected by the client
               xml["ext"].cssStationId
-              xml["ext"].SecurityLevel 9
+              xml["ext"].SecurityLevel security_level
             end
           end
         end

--- a/lib/vbms/requests/remove_contention.rb
+++ b/lib/vbms/requests/remove_contention.rb
@@ -1,6 +1,8 @@
 module VBMS
   module Requests
     class RemoveContention < BaseRequest
+      include AddExtSecurityHeader
+
       NAMESPACES = {
         "xmlns:cla" => "http://vbms.vba.va.gov/external/ClaimService/v4",
         "xmlns:cdm" => "http://vbms.vba.va.gov/cdm/claim/v4",
@@ -29,19 +31,6 @@ module VBMS
 
       def endpoint_url(base_url)
         "#{base_url}#{VBMS::ENDPOINTS[specify_endpoint]}"
-      end
-
-      def inject_header_content(header_xml)
-        Nokogiri::XML::Builder.with(header_xml) do |xml|
-          xml["vbmsext"].userId("dslogon.1011239249", "xmlns:vbmsext" => "http://vbms.vba.va.gov/external")
-          if @send_userid
-            xml["ext"].Security("xmlns:ext" => "http://vbms.vba.va.gov/external") do
-              xml["ext"].cssUserName # do not insert css id in here, this will be injected by the client
-              xml["ext"].cssStationId
-              xml["ext"].SecurityLevel security_level
-            end
-          end
-        end
       end
 
       def namespaces

--- a/lib/vbms/requests/remove_contention.rb
+++ b/lib/vbms/requests/remove_contention.rb
@@ -38,7 +38,7 @@ module VBMS
             xml["ext"].Security("xmlns:ext" => "http://vbms.vba.va.gov/external") do
               xml["ext"].cssUserName # do not insert css id in here, this will be injected by the client
               xml["ext"].cssStationId
-              xml["ext"].SecurityLevel 9
+              xml["ext"].SecurityLevel security_level
             end
           end
         end

--- a/lib/vbms/requests/remove_contention.rb
+++ b/lib/vbms/requests/remove_contention.rb
@@ -13,9 +13,10 @@ module VBMS
         "xmlns:comon" => "http://vbms.vba.va.gov/cdm/comon/v5"
       }.freeze
 
-      def initialize(contention:, v5: false)
+      def initialize(contention:, v5: false, send_userid: false)
         @contention = contention
         @v5 = v5
+        @send_userid = send_userid
       end
 
       def name
@@ -33,6 +34,13 @@ module VBMS
       def inject_header_content(header_xml)
         Nokogiri::XML::Builder.with(header_xml) do |xml|
           xml["vbmsext"].userId("dslogon.1011239249", "xmlns:vbmsext" => "http://vbms.vba.va.gov/external")
+          if @send_userid
+            xml["ext"].Security("xmlns:ext" => "http://vbms.vba.va.gov/external") do
+              xml["ext"].cssUserName # do not insert css id in here, this will be injected by the client
+              xml["ext"].cssStationId
+              xml["ext"].SecurityLevel 9
+            end
+          end
         end
       end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -5,8 +5,9 @@ describe VBMS::Client do
     @client = new_test_client
   end
 
-  let(:doc) do
-    Nokogiri::XML(<<-EOF)
+  describe "remove_must_understand" do
+    it "takes a Nokogiri document and deletes the mustUnderstand attribute" do
+      doc = Nokogiri::XML(<<-EOF)
       <?xml version="1.0" encoding="UTF-8"?>
       <soapenv:Envelope
            xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
@@ -16,49 +17,8 @@ describe VBMS::Client do
           </wsse:Security>
         </soapenv:Header>
       </soapenv:Envelope>
-    EOF
-  end
+      EOF
 
-  describe "inject_saml" do
-    let(:injected_css_id) do
-      doc.at_xpath(
-        "//saml2:Attribute[@Name ='http://vba.va.gov/css/common/subjectId']/saml2:AttributeValue",
-        "xmlns:saml2" => "urn:oasis:names:tc:SAML:2.0:assertion"
-      ).child.text
-    end
-
-    let(:injected_station_id) do
-      doc.at_xpath(
-        "//saml2:Attribute[@Name ='http://vba.va.gov/css/common/stationId']/saml2:AttributeValue",
-        "xmlns:saml2" => "urn:oasis:names:tc:SAML:2.0:assertion"
-      ).child.text
-    end
-
-    context "with css data passed" do
-      before do
-        @client = new_test_client(css_id: "KLAYTHOMPSON", station_id: "415")
-      end
-
-      it "adds saml token to the request with the user data" do
-        @client.inject_saml(doc)
-
-        expect(injected_css_id).to eq("KLAYTHOMPSON")
-        expect(injected_station_id).to eq("415")
-      end
-    end
-
-    context "with no css data passed" do
-      it "adds saml token to the request with the default user data" do
-        @client.inject_saml(doc)
-
-        expect(injected_css_id).to eq("0")
-        expect(injected_station_id).to eq("0")
-      end
-    end
-  end
-
-  describe "remove_must_understand" do
-    it "takes a Nokogiri document and deletes the mustUnderstand attribute" do
       @client.remove_must_understand(doc)
 
       expect(doc.to_s).not_to include("mustUnderstand")

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -115,6 +115,48 @@ describe VBMS::Client do
     end
   end
 
+  describe "inject_header_content" do
+    it "injects username and station id" do
+      veteran_record = {
+        file_number: "561349920",
+        sex: "M",
+        first_name: "Stan",
+        last_name: "Stanman",
+        ssn: "796164121",
+        address_line1: "Shrek's Swamp",
+        address_line2: "",
+        address_line3: "",
+        city: "Charleston",
+        state: "SC",
+        country: "USA",
+        zip_code: "29401"
+      }
+
+      claim = {
+        benefit_type_code: "1",
+        payee_code: "00",
+        station_of_jurisdiction: "317",
+        end_product_code: "070CERT2AMC",
+        end_product_modifier: "071",
+        end_product_label: "AMC-Cert to BVA",
+        predischarge: false,
+        gulf_war_registry: false,
+        date: 20.days.ago.to_date,
+        suppress_acknowledgment_letter: false,
+        limited_poa_code: "007",
+        limited_poa_access: true
+      }
+
+      request = VBMS::Requests::EstablishClaim.new(veteran_record, claim, v5: true, send_userid: true)
+      @client = new_test_client(css_id: "KLAYTHOMPSON", station_id: "415")
+
+      doc = @client.inject_header_content(SoapScum::WSSecurity.encrypt(request.soap_doc, request.signed_elements), request)
+      expect(doc.at_xpath("//ext:cssUserName", "ext" => "http://vbms.vba.va.gov/external").content).to eq("KLAYTHOMPSON")
+      expect(doc.at_xpath("//ext:cssStationId", "ext" => "http://vbms.vba.va.gov/external").content).to eq("415")
+      expect(doc.at_xpath("//ext:SecurityLevel", "ext" => "http://vbms.vba.va.gov/external").content).to eq("9")
+    end
+  end
+
   describe "process_response" do
     let(:request) { double("request", mtom_attachment?: false) }
     let(:response_body) { "" }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -151,13 +151,15 @@ def parsed_timestamp(xml)
 end
 
 # to generate test files, run rake fixtures
-def new_test_client(use_forward_proxy: false)
+def new_test_client(css_id: nil, station_id: nil, use_forward_proxy: false)
   VBMS::Client.new(
     base_url: "http://test.endpoint.url/",
     keypass: "importkey",
     client_keyfile: fixture_path("test_client.p12"),
     server_cert: fixture_path("test_server.crt"),
     saml: fixture_path("test_samltoken.xml"),
+    css_id: css_id,
+    station_id: station_id,
     use_forward_proxy: use_forward_proxy,
     proxy_base_url: use_forward_proxy ? "http://localhost:3000" : nil
   )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -151,15 +151,13 @@ def parsed_timestamp(xml)
 end
 
 # to generate test files, run rake fixtures
-def new_test_client(css_id: nil, station_id: nil, use_forward_proxy: false)
+def new_test_client(use_forward_proxy: false)
   VBMS::Client.new(
     base_url: "http://test.endpoint.url/",
     keypass: "importkey",
     client_keyfile: fixture_path("test_client.p12"),
     server_cert: fixture_path("test_server.crt"),
     saml: fixture_path("test_samltoken.xml"),
-    css_id: css_id,
-    station_id: station_id,
     use_forward_proxy: use_forward_proxy,
     proxy_base_url: use_forward_proxy ? "http://localhost:3000" : nil
   )


### PR DESCRIPTION
Connects https://github.com/department-of-veterans-affairs/caseflow/issues/6938

Sample request now looks like this:

```
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" 
xmlns:cdm="http://vbms.vba.va.gov/cdm/claim/v5" 
xmlns:cla="http://vbms.vba.va.gov/external/ClaimService/v5" 
xmlns:doc="http://vbms.vba.va.gov/cdm/document/v4" 
xmlns:participant="http://vbms.vba.va.gov/cdm/participant/v5" 
xmlns:read="http://service.efolder.vbms.vba.va.gov/eFolderReadService" 
xmlns:upload="http://service.efolder.vbms.vba.va.gov/eFolderUploadService" 
xmlns:v4="http://vbms.vba.va.gov/external/eDocumentService/v4" 
xmlns:v5="http://vbms.vba.va.gov/cdm/document/v5" 
xmlns:xop="http://www.w3.org/2004/08/xop/include">
  <soapenv:Header>
    <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
      ....
    </wsse:Security>
    <vbmsext:userId xmlns:vbmsext="http://vbms.vba.va.gov/external">dslogon.1011239249</vbmsext:userId>
    <ext:Security xmlns:ext="http://vbms.vba.va.gov/external">
      <ext:cssUserName>KLAYTHOMPSON</ext:cssUserName>
      <ext:cssStationId>415</ext:cssStationId>
      <ext:SecurityLevel>9</ext:SecurityLevel>
    </ext:Security>
  </soapenv:Header>
  <soapenv:Body>
     ...
  </soapenv:Body>
</soapenv:Envelope>

```

### To do
- [x] test against uat

Tested on UAT by doing the following using user nherro_ssuper/317:
- created a established a claim
- created 2 contentions for that claim
- deleted 1 contention
- viewed list of contentions and verified there was only 1 left
