### PR TITLE
Add optional data for original_contention_ids

### DIFF
--- a/lib/vbms/requests/create_contentions.rb
+++ b/lib/vbms/requests/create_contentions.rb
@@ -41,9 +41,6 @@ module VBMS
         VBMS::Requests.soap(more_namespaces: @v5 ? NAMESPACES_V5 : NAMESPACES) do |xml|
           xml["cla"].createContentions do
             @contentions.each do |contention|
-
-              original_contention_ids =
-
               xml["cla"].contentionsToCreate({
                 # 0 means the id will be auto generated
                 id: "0",
@@ -80,11 +77,6 @@ module VBMS
         end
       end
 
-      def original_contention_ids(contention)
-        return {} unless contention[:original_contention_ids]
-        { "origContentionIds" => contention[:original_contention_ids].join(" ") }
-      end
-
       def signed_elements
         [["/soapenv:Envelope/soapenv:Body",
           { soapenv: SoapScum::XMLNamespaces::SOAPENV },
@@ -107,6 +99,13 @@ module VBMS
             VBMS::Responses::Contention.create_from_xml(xml, key: :created_contentions)
           end
         end
+      end
+
+      private
+
+      def original_contention_ids(contention)
+        return {} unless contention[:original_contention_ids]
+        { "origContentionIds" => contention[:original_contention_ids].join(" ") }
       end
     end
   end

--- a/lib/vbms/requests/create_contentions.rb
+++ b/lib/vbms/requests/create_contentions.rb
@@ -41,7 +41,10 @@ module VBMS
         VBMS::Requests.soap(more_namespaces: @v5 ? NAMESPACES_V5 : NAMESPACES) do |xml|
           xml["cla"].createContentions do
             @contentions.each do |contention|
-              xml["cla"].contentionsToCreate(
+
+              original_contention_ids =
+
+              xml["cla"].contentionsToCreate({
                 # 0 means the id will be auto generated
                 id: "0",
 
@@ -59,7 +62,7 @@ module VBMS
 
                 awaitingResponse: "unused. but required.",
                 partcipantContention: "unused, but required."
-              ) do
+              }.merge(original_contention_ids(contention))) do
                 xml["cdm"].submitDate Date.today.iso8601
 
                 contention[:special_issues] && contention[:special_issues].each do |special_issue|
@@ -75,6 +78,11 @@ module VBMS
             end
           end
         end
+      end
+
+      def original_contention_ids(contention)
+        return {} unless contention[:original_contention_ids]
+        { "origContentionIds" => contention[:original_contention_ids].join(" ") }
       end
 
       def signed_elements

--- a/lib/vbms/requests/create_contentions.rb
+++ b/lib/vbms/requests/create_contentions.rb
@@ -105,6 +105,7 @@ module VBMS
 
       def original_contention_ids(contention)
         return {} unless contention[:original_contention_ids]
+        
         { "origContentionIds" => contention[:original_contention_ids].join(" ") }
       end
     end

--- a/spec/requests/create_contentions_spec.rb
+++ b/spec/requests/create_contentions_spec.rb
@@ -7,7 +7,7 @@ describe VBMS::Requests::CreateContentions do
       contentions: [
         { description: "Billy One" },
         { description: "Billy Two" },
-        { description: "Billy Three" }
+        { description: "Billy Three", original_contention_ids: [1, 2] }
       ]
     )
   end
@@ -46,7 +46,11 @@ describe VBMS::Requests::CreateContentions do
       VBMS::Requests::CreateContentions.new(
         veteran_file_number: "1232",
         claim_id: "1323123",
-        contentions: [{ description: "Billy One" }, { description: "Billy Two" }, { description: "Billy Three" }],
+        contentions: [
+          { description: "Billy One" },
+          { description: "Billy Two" },
+          { description: "Billy Three", original_contention_ids: [1, 2] }
+        ],
         v5: true
       )
     end


### PR DESCRIPTION
Allows us to send the original contention IDs for DTA contentions.  This has been tested against VBMS in UAT with 0, 1, and 2 original_contention_ids.

connects https://github.com/department-of-veterans-affairs/connect_vbms/issues/219
related https://github.com/department-of-veterans-affairs/caseflow/issues/10756