### PR TITLE
Set open_timeout to 10 seconds

### DIFF
--- a/lib/vbms/client.rb
+++ b/lib/vbms/client.rb
@@ -173,7 +173,7 @@ module VBMS
 
       request = HTTPI::Request.new(endpoint_url)
 
-      request.open_timeout               = 600 # seconds
+      request.open_timeout               = 10 # seconds
       request.read_timeout               = 600 # seconds
       request.auth.ssl.cert_key          = SoapScum::WSSecurity.client_key
       request.auth.ssl.cert_key_password = @keypass


### PR DESCRIPTION
**Why**: Open timeouts should be very low in general because that's
for the initial connection, as opposed to the time waiting for a
response after a successful connection, which is what `read_timeout`
is for. I would normally set `open_timeout` to 5 seconds or less, but
I set it to 10 to match a recent change in the `ruby-bgs` repo.