### PR TITLE
Extra carriage return in response

### DIFF
--- a/lib/vbms/helpers/multipart_parser.rb
+++ b/lib/vbms/helpers/multipart_parser.rb
@@ -33,7 +33,7 @@ class MultipartParser
   def find_boundary
     # if it is a multipart, the boundary is at location zero
     lines = @response.body.split("\r\n")
-    lines.shift if lines[0] == ""
+    lines.shift while lines[0] == ""
     lines[0].strip
   end
 

--- a/lib/vbms/helpers/multipart_parser.rb
+++ b/lib/vbms/helpers/multipart_parser.rb
@@ -32,7 +32,9 @@ class MultipartParser
 
   def find_boundary
     # if it is a multipart, the boundary is at location zero
-    @response.body.split("\r\n")[0].strip
+    lines = @response.body.split("\r\n")
+    lines.shift if lines[0] == ""
+    lines[0].strip
   end
 
   def split_based_on_boundary

--- a/spec/helpers/multipart_parser_spec.rb
+++ b/spec/helpers/multipart_parser_spec.rb
@@ -15,9 +15,9 @@ describe MultipartParser do
         it { is_expected.to eq "<tag>This is the contents</tag>\r\n" }
       end
 
-      context "with a single XML file with leading carriage return" do
+      context "with a single XML file with leading carriage return delimiter" do
         let(:body) do
-          "\r\n--uuid:61b\r\nContent-Type: application/xop+xml\r\n\r\n"\
+          "\r\n\r\n--uuid:61b\r\nContent-Type: application/xop+xml\r\n\r\n"\
           "<tag>This is the contents</tag>\r\n--uuid:61b--"
         end
         it { is_expected.to eq "<tag>This is the contents</tag>\r\n" }

--- a/spec/helpers/multipart_parser_spec.rb
+++ b/spec/helpers/multipart_parser_spec.rb
@@ -15,6 +15,14 @@ describe MultipartParser do
         it { is_expected.to eq "<tag>This is the contents</tag>\r\n" }
       end
 
+      context "with a single XML file with leading carriage return" do
+        let(:body) do
+          "\r\n--uuid:61b\r\nContent-Type: application/xop+xml\r\n\r\n"\
+          "<tag>This is the contents</tag>\r\n--uuid:61b--"
+        end
+        it { is_expected.to eq "<tag>This is the contents</tag>\r\n" }
+      end
+
       context "with a XML file and file attachment" do
         let(:body) do
           "--uuid:61b" \


### PR DESCRIPTION
We occasionally see an extra carriage return delimiter prepended to multipart XML responses. This change makes our parser more resilient to that pattern.

Confirmed in UAT that this fixes problematic responses.