### PR TITLE
Rename `transient?` to `ignorable?`

### DIFF
--- a/lib/vbms/errors.rb
+++ b/lib/vbms/errors.rb
@@ -15,7 +15,7 @@ module VBMS
       "Could not access remote service at"
     ].freeze
 
-    def transient?
+    def ignorable?
       TRANSIENT_ERRORS.any? { |transient_error| message.include?(transient_error) }
     end
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -96,7 +96,7 @@ describe VBMS::Client do
             expect(error.class).to eq VBMS::HTTPError
             expect(error.code).to eq 400
             expect(error.body).to eq "generic"
-            expect(error).to_not be_transient
+            expect(error).to_not be_ignorable
           end
         end
       end
@@ -110,7 +110,7 @@ describe VBMS::Client do
             expect(error.class).to eq VBMS::HTTPError
             expect(error.code).to eq 400
             expect(error.body).to eq "FAILED FOR UNKNOWN REASONS"
-            expect(error).to be_transient
+            expect(error).to be_ignorable
           end
         end
       end


### PR DESCRIPTION
**Why**: We want to identify errors that can be ignored from services
like Sentry, whether they are transient or some other type of
non-actionable error.