### PR TITLE
Add same station special issue to update contention

### DIFF
--- a/lib/vbms/requests/update_contention.rb
+++ b/lib/vbms/requests/update_contention.rb
@@ -58,6 +58,15 @@ module VBMS
               "workingContention" => @contention[:working_contention] # required
             ) do
               xml["cdm"].submitDate @contention[:submit_date]
+
+              @contention[:special_issues]&.each do |special_issue|
+                xml["cdm"].issue(
+                  typeCd: special_issue[:code],
+                  narrative: special_issue[:narrative],
+                  inferred: "false"
+                )
+              end
+              
               xml["cdm"].startDate @contention[:start_date]
               xml["cdm"].origSrc "APP" if @v5
             end

--- a/lib/vbms/requests/update_contention.rb
+++ b/lib/vbms/requests/update_contention.rb
@@ -66,7 +66,7 @@ module VBMS
                   inferred: "false"
                 )
               end
-              
+
               xml["cdm"].startDate @contention[:start_date]
               xml["cdm"].origSrc "APP" if @v5
             end


### PR DESCRIPTION
When we update contentions (such as the contention text), we are inadvertently dropping special issues such as same station review or legacy issue opt in.

This PR alone does not fix this problem, because we are also not getting special issues when we fetch contentions from VBMS, and we're only using that data as a basis for the rest of the contention data right now.  But this is a pre-requisite to fixing the entire issue.

This has been tested in UAT with both a contention that has special issues, and a contention that does not.

Note - this came about because it's needed for fixing some data where there were manually created contentions in VBMS. (https://github.com/department-of-veterans-affairs/caseflow/issues/11249)