### PR TITLE
Set correct contention type when creating contention

### DIFF
--- a/lib/vbms/requests/create_contentions.rb
+++ b/lib/vbms/requests/create_contentions.rb
@@ -57,7 +57,7 @@ module VBMS
 
                 actionableItem: "true",
                 medical: "true",
-                typeCode: "REP",
+                typeCode: contention[:contention_type].present? ? contention[:contention_type] : "REP",
                 workingContention: "YES",
 
                 awaitingResponse: "unused. but required.",

--- a/spec/requests/create_contentions_spec.rb
+++ b/spec/requests/create_contentions_spec.rb
@@ -8,7 +8,8 @@ describe VBMS::Requests::CreateContentions do
       contentions: [
         { description: "Billy One" },
         { description: "Billy Two" },
-        { description: "Billy Three", original_contention_ids: [1, 2] }
+        { description: "Billy Three", original_contention_ids: [1, 2] },
+        { contention_type: "HLR" }
       ],
       claim_date: 20.days.ago.to_date
     )
@@ -51,7 +52,8 @@ describe VBMS::Requests::CreateContentions do
         contentions: [
           { description: "Billy One" },
           { description: "Billy Two" },
-          { description: "Billy Three", original_contention_ids: [1, 2] }
+          { description: "Billy Three", original_contention_ids: [1, 2]  },
+          { contention_type: "HLR" }
         ],
         claim_date: 20.days.ago.to_date,
         v5: true

--- a/spec/requests/create_contentions_spec.rb
+++ b/spec/requests/create_contentions_spec.rb
@@ -8,8 +8,7 @@ describe VBMS::Requests::CreateContentions do
       contentions: [
         { description: "Billy One" },
         { description: "Billy Two" },
-        { description: "Billy Three", original_contention_ids: [1, 2] },
-        { contention_type: "HLR" }
+        { description: "Billy Three", original_contention_ids: [1, 2], contention_type: "HLR" }
       ],
       claim_date: 20.days.ago.to_date
     )
@@ -52,8 +51,7 @@ describe VBMS::Requests::CreateContentions do
         contentions: [
           { description: "Billy One" },
           { description: "Billy Two" },
-          { description: "Billy Three", original_contention_ids: [1, 2]  },
-          { contention_type: "HLR" }
+          { description: "Billy Three", original_contention_ids: [1, 2], contention_type: "HLR" }
         ],
         claim_date: 20.days.ago.to_date,
         v5: true


### PR DESCRIPTION
Connects #11401

Before setting contention_type. It shows type_code: "REP"
<img width="1234" alt="Screen Shot 2019-09-24 at 10 48 44 AM" src="https://user-images.githubusercontent.com/23080951/65531240-7720b080-dec7-11e9-8678-4f9673ae8c10.png">

After setting contention_type. It shows type_code: "HLR"
<img width="1233" alt="Screen Shot 2019-09-24 at 11 08 04 AM" src="https://user-images.githubusercontent.com/23080951/65531334-a2a39b00-dec7-11e9-9a62-89217f9bf1aa.png">

