### PR TITLE
Treat HTTPClient::ReceiveTimeoutError as ignorable

### DIFF
--- a/lib/vbms/errors.rb
+++ b/lib/vbms/errors.rb
@@ -22,6 +22,9 @@ module VBMS
       # https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/4708/
       "HTTPClient::KeepAliveDisconnected:",
 
+      # https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/7710/
+      "HTTPClient::ReceiveTimeoutError",
+
       # https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/3170/
       "Unable to find SOAP operation",
 


### PR DESCRIPTION
long-running async jobs may occasionally throw these. e.g. https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/7710/