### PR TITLE
Pagination bug

### DIFF
--- a/lib/vbms/service/paged_documents.rb
+++ b/lib/vbms/service/paged_documents.rb
@@ -19,12 +19,11 @@ module VBMS
         pages = 1
 
         # if we need to fetch more docs, iterate till we exhaust the pages
-        while total_docs > documents.length
+        while total_docs > documents.length && next_offset > 0
           next_page = client.send_request(next_request(file_number, next_offset))
           (documents << next_page.map { |section| section[:documents] }).flatten!
           next_offset = next_page.first[:paging][:@next_start_index].to_i
           pages += 1
-          break if next_offset <= 0 # reality check
         end
 
         { paging: pagination, pages: pages, documents: documents }

--- a/spec/service/paged_documents_spec.rb
+++ b/spec/service/paged_documents_spec.rb
@@ -71,7 +71,7 @@ describe VBMS::Service::PagedDocuments do
 
     context "when the first page reports more pages than it contains" do
       let(:small_return_set) { true }
-      let(:total_docs) { 19 } # smaller than page size
+      let(:total_docs) { page_size - 1 }
 
       it "believes the next_offset over the returned document count" do
         r = subject.call(file_number: file_number)


### PR DESCRIPTION
connects #249 

VBMS efolder may response with fewer actual documents than it reports in its metadata.

E.g. an efolder response claims there are 344 total docs, but returns only 334 of them.
 
```
# first page of results returns 334 docs with metadata
{:@filtered_results=>"10", :@next_start_index=>"-1", :@total_result_count=>"344"}
irb(main):042:0> docs.flatten.length
=> 334
irb(main):043:0> total_docs = pagination[:@total_result_count].to_i
=> 344
```

Previously this gem would respect the `@total_result_count` as authoritative. Now, it respects the `@next_start_index` when ultimately deciding to request another page.