### PR TITLE
Raise error on empty paged responses

### DIFF
--- a/lib/vbms/errors.rb
+++ b/lib/vbms/errors.rb
@@ -183,6 +183,9 @@ module VBMS
     end
   end
 
+  class ZeroPagesError < ClientError
+  end
+
   class BadClaim < HTTPError; end
   class BadPostalCode < HTTPError; end
   class BadSOAPMessage < HTTPError; end

--- a/lib/vbms/service/paged_documents.rb
+++ b/lib/vbms/service/paged_documents.rb
@@ -11,6 +11,9 @@ module VBMS
         req = next_request(file_number, 0)
         first_page = client.send_request(req)
 
+        # interpret a first page with no sections (and no doc count) as equivalent to zero pages.
+        raise ClientError.new("No sections found in first page") if first_page.empty?
+
         # response will always be an array. get pagination from the first section.
         (documents << first_page.map { |section| section[:documents] }).flatten!
         pagination = first_page.first[:paging]

--- a/lib/vbms/service/paged_documents.rb
+++ b/lib/vbms/service/paged_documents.rb
@@ -12,7 +12,7 @@ module VBMS
         first_page = client.send_request(req)
 
         # interpret a first page with no sections (and no doc count) as equivalent to zero pages.
-        raise ClientError.new("No sections found in first page") if first_page.empty?
+        raise ZeroPagesError.new("No sections found in first page") if first_page.empty?
 
         # response will always be an array. get pagination from the first section.
         (documents << first_page.map { |section| section[:documents] }).flatten!

--- a/spec/service/paged_documents_spec.rb
+++ b/spec/service/paged_documents_spec.rb
@@ -81,5 +81,12 @@ describe VBMS::Service::PagedDocuments do
         expect(r[:paging][:@total_result_count]).to eq total_docs
       end
     end
+
+    context "when the first page contains no sections" do
+      it "raises a ClientError" do
+        allow(client).to receive(:send_request).and_return []
+        expect { subject.call(file_number: file_number) }.to raise_error(VBMS::ClientError)
+      end
+    end
   end
 end

--- a/spec/service/paged_documents_spec.rb
+++ b/spec/service/paged_documents_spec.rb
@@ -83,9 +83,9 @@ describe VBMS::Service::PagedDocuments do
     end
 
     context "when the first page contains no sections" do
-      it "raises a ClientError" do
+      it "raises a ZeroPagesError" do
         allow(client).to receive(:send_request).and_return []
-        expect { subject.call(file_number: file_number) }.to raise_error(VBMS::ClientError)
+        expect { subject.call(file_number: file_number) }.to raise_error(VBMS::ZeroPagesError)
       end
     end
   end


### PR DESCRIPTION
Connects #251 

This appears to be the first instance of connect_vbms raising an error for a request/response that's valid at the HTTP and SOAP levels. I wasn't sure if it's better to just raise a `ClientError`, or to raise an instance of a subclass (`PagingError`?)