### PR TITLE
Upgrade rake to address CVE-2020-8130

### DIFF
--- a/connect_vbms.gemspec
+++ b/connect_vbms.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "httplog"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-nav"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.3"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "simplecov", "~> 0.10"


### PR DESCRIPTION
Discovered via a recent CI build: https://travis-ci.org/department-of-veterans-affairs/connect_vbms/builds/658426989